### PR TITLE
Add measurement type management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - **Đơn hàng** – theo dõi danh sách và chi tiết đơn hàng
 - **Số đo** – lưu trữ các số đo của khách hàng
 - **Loại sản phẩm** – quản lý loại sản phẩm và các thông số đi kèm
+- **Loại số đo** – tạo và liệt kê các loại thông số đo
 
 ## Xây dựng
 Chạy `ant compile` để biên dịch dự án và `ant test` để chạy các kiểm thử mặc định. Điều chỉnh thông tin kết nối trong `src/java/dao/connect/DBConnect.java` cho môi trường của bạn.

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
@@ -1,0 +1,30 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeCreateController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.getRequestDispatcher("/jsp/measurementtype/createMeasurementType.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String name = request.getParameter("name");
+        String unit = request.getParameter("unit");
+        MeasurementType mt = new MeasurementType();
+        mt.setName(name);
+        mt.setUnit(unit);
+        measurementTypeDAO.insert(mt);
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
@@ -1,0 +1,22 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+public class MeasurementTypeListController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<MeasurementType> list = measurementTypeDAO.findAll();
+        request.setAttribute("measurementTypes", list);
+        request.getRequestDispatcher("/jsp/measurementtype/listMeasurementType.jsp").forward(request, response);
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
@@ -26,4 +26,16 @@ public class MeasurementTypeDAO {
         }
         return list;
     }
+
+    public void insert(MeasurementType mt) {
+        String sql = "INSERT INTO loai_thong_so(ten_thong_so, don_vi) VALUES(?,?)";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, mt.getName());
+            ps.setString(2, mt.getUnit());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -97,6 +97,24 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeListController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <url-pattern>/measurement-types</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeCreateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <url-pattern>/measurement-types/create</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>CustomerCreateController</servlet-name>
         <servlet-class>controller.customer.CustomerCreateController</servlet-class>
     </servlet>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
@@ -1,0 +1,14 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <title>Thêm loại số đo</title>
+</head>
+<body>
+<h2>Thêm loại số đo</h2>
+<form action="" method="post">
+    Tên thông số: <input type="text" name="name"/><br/>
+    Đơn vị: <input type="text" name="unit" value="cm"/><br/>
+    <input type="submit" value="Lưu"/>
+</form>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
@@ -1,0 +1,25 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Danh sách loại số đo</title>
+</head>
+<body>
+<h2>Danh sách loại số đo</h2>
+<a href="<c:url value='/measurement-types/create'/>">Thêm loại số đo</a>
+<table border="1">
+    <tr>
+        <th>Mã</th>
+        <th>Tên thông số</th>
+        <th>Đơn vị</th>
+    </tr>
+    <c:forEach var="mt" items="${measurementTypes}">
+        <tr>
+            <td>${mt.id}</td>
+            <td>${mt.name}</td>
+            <td>${mt.unit}</td>
+        </tr>
+    </c:forEach>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support creating and listing measurement types
- wire up measurement type controllers in web.xml
- document measurement type management in README

## Testing
- `ant -q compile`

------
https://chatgpt.com/codex/tasks/task_b_688d161f4b7c83229d64c7010f7603d1