### PR TITLE
Add measurement type management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - **Khách hàng** – liệt kê, thêm mới và cập nhật khách hàng
 - **Kho vải** – quản lý các loại vải trong kho
 - **Đơn hàng** – theo dõi danh sách và chi tiết đơn hàng
-- **Số đo** – lưu trữ các số đo của khách hàng
+- **Số đo** – quản lý danh mục các loại số đo (tạo, cập nhật, xóa, liệt kê)
 - **Loại sản phẩm** – quản lý loại sản phẩm và các thông số đi kèm
 
 ## Xây dựng

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
@@ -1,0 +1,30 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeCreateController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.getRequestDispatcher("/jsp/measurementtype/createMeasurementType.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String name = request.getParameter("name");
+        String unit = request.getParameter("unit");
+        MeasurementType mt = new MeasurementType();
+        mt.setName(name);
+        mt.setUnit(unit);
+        measurementTypeDAO.insert(mt);
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeDeleteController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeDeleteController.java
@@ -1,0 +1,23 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeDeleteController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String idStr = request.getParameter("id");
+        if (idStr != null) {
+            int id = Integer.parseInt(idStr);
+            measurementTypeDAO.delete(id);
+        }
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
@@ -1,0 +1,22 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+public class MeasurementTypeListController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<MeasurementType> list = measurementTypeDAO.findAll();
+        request.setAttribute("measurementTypes", list);
+        request.getRequestDispatcher("/jsp/measurementtype/listMeasurementType.jsp").forward(request, response);
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeUpdateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeUpdateController.java
@@ -1,0 +1,40 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeUpdateController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String idStr = request.getParameter("id");
+        if (idStr != null) {
+            int id = Integer.parseInt(idStr);
+            MeasurementType mt = measurementTypeDAO.findById(id);
+            request.setAttribute("measurementType", mt);
+            request.getRequestDispatcher("/jsp/measurementtype/updateMeasurementType.jsp").forward(request, response);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/measurement-types");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        int id = Integer.parseInt(request.getParameter("id"));
+        String name = request.getParameter("name");
+        String unit = request.getParameter("unit");
+        MeasurementType mt = new MeasurementType();
+        mt.setId(id);
+        mt.setName(name);
+        mt.setUnit(unit);
+        measurementTypeDAO.update(mt);
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
@@ -26,4 +26,60 @@ public class MeasurementTypeDAO {
         }
         return list;
     }
+
+    public void insert(MeasurementType mt) {
+        String sql = "INSERT INTO loai_thong_so(ten_thong_so, don_vi) VALUES(?,?)";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, mt.getName());
+            ps.setString(2, mt.getUnit());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public MeasurementType findById(int id) {
+        String sql = "SELECT ma_thong_so, ten_thong_so, don_vi FROM loai_thong_so WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    MeasurementType mt = new MeasurementType();
+                    mt.setId(rs.getInt("ma_thong_so"));
+                    mt.setName(rs.getString("ten_thong_so"));
+                    mt.setUnit(rs.getString("don_vi"));
+                    return mt;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public void update(MeasurementType mt) {
+        String sql = "UPDATE loai_thong_so SET ten_thong_so = ?, don_vi = ? WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, mt.getName());
+            ps.setString(2, mt.getUnit());
+            ps.setInt(3, mt.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void delete(int id) {
+        String sql = "DELETE FROM loai_thong_so WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -97,6 +97,42 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeListController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <url-pattern>/measurement-types</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeCreateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <url-pattern>/measurement-types/create</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeUpdateController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeUpdateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeUpdateController</servlet-name>
+        <url-pattern>/measurement-types/update</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeDeleteController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeDeleteController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeDeleteController</servlet-name>
+        <url-pattern>/measurement-types/delete</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>CustomerCreateController</servlet-name>
         <servlet-class>controller.customer.CustomerCreateController</servlet-class>
     </servlet>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
@@ -1,0 +1,15 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Thêm loại số đo</title>
+</head>
+<body>
+<h2>Thêm loại số đo</h2>
+<form action="<c:url value='/measurement-types/create'/>" method="post">
+    Tên thông số: <input type="text" name="name"/><br/>
+    Đơn vị: <input type="text" name="unit" value="cm"/><br/>
+    <input type="submit" value="Lưu"/>
+</form>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
@@ -1,0 +1,29 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Danh sách loại số đo</title>
+</head>
+<body>
+<h2>Danh sách loại số đo</h2>
+<a href="<c:url value='/measurement-types/create'/>">Thêm loại số đo</a>
+<table border="1">
+    <tr>
+        <th>Mã</th>
+        <th>Tên thông số</th>
+        <th>Đơn vị</th>
+        <th>Sửa</th>
+        <th>Xóa</th>
+    </tr>
+    <c:forEach var="mt" items="${measurementTypes}">
+        <tr>
+            <td>${mt.id}</td>
+            <td>${mt.name}</td>
+            <td>${mt.unit}</td>
+            <td><a href="<c:url value='/measurement-types/update?id=${mt.id}'/>">Sửa</a></td>
+            <td><a href="<c:url value='/measurement-types/delete?id=${mt.id}'/>" onclick="return confirm('Bạn có chắc muốn xóa?');">Xóa</a></td>
+        </tr>
+    </c:forEach>
+</table>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/updateMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/updateMeasurementType.jsp
@@ -1,0 +1,16 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Cập nhật loại số đo</title>
+</head>
+<body>
+<h2>Cập nhật loại số đo</h2>
+<form action="<c:url value='/measurement-types/update'/>" method="post">
+    <input type="hidden" name="id" value="${measurementType.id}"/>
+    Tên thông số: <input type="text" name="name" value="${measurementType.name}"/><br/>
+    Đơn vị: <input type="text" name="unit" value="${measurementType.unit}"/><br/>
+    <input type="submit" value="Cập nhật"/>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support creating, listing, updating, and deleting measurement types
- wire up measurement type update and delete controllers in web.xml
- document measurement type catalog management and clarify functionality
- standardize edit and delete links in the measurement type list JSP
- use `<c:url>` in measurement type creation and update forms for consistent URL handling

## Testing
- `ant -q -f TailorSoft_COCOLAND/build.xml compile` *(fails: `ant` command not found)*
- `apt-get install -y ant` *(fails: ca-certificates-java post-installation error)*


------
https://chatgpt.com/codex/tasks/task_b_688d161f4b7c83229d64c7010f7603d1