### PR TITLE
Add measurement type management and customer order history

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Đây là ứng dụng web Java đơn giản giúp quản lý các công việc may đo. Ứng dụng minh họa các thao tác CRUD cơ bản thông qua servlet, các lớp DAO và trang JSP. Toàn bộ giao diện đã được Việt hóa. Cơ sở dữ liệu mẫu nằm tại `db/cocoland_schema.sql`.
 
 ## Chức năng
-- **Khách hàng** – liệt kê, thêm mới và cập nhật khách hàng
+- **Khách hàng** – liệt kê, thêm mới, cập nhật và xem lịch sử đặt may theo từng sản phẩm với nút xem chi tiết đơn hàng; bảng khách hàng hiển thị thêm ngày tạo và liên kết tới lịch sử đặt may
 - **Kho vải** – quản lý các loại vải trong kho
 - **Đơn hàng** – theo dõi danh sách và chi tiết đơn hàng
-- **Số đo** – lưu trữ các số đo của khách hàng
+- **Số đo** – quản lý danh mục các loại số đo (tạo, cập nhật, xóa, liệt kê); đây là danh mục định nghĩa chung không lưu số đo theo từng khách hàng
 - **Loại sản phẩm** – quản lý loại sản phẩm và các thông số đi kèm
 
 ## Xây dựng

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeCreateController.java
@@ -1,0 +1,30 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeCreateController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        request.getRequestDispatcher("/jsp/measurementtype/createMeasurementType.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String name = request.getParameter("name");
+        String unit = request.getParameter("unit");
+        MeasurementType mt = new MeasurementType();
+        mt.setName(name);
+        mt.setUnit(unit);
+        measurementTypeDAO.insert(mt);
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeDeleteController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeDeleteController.java
@@ -1,0 +1,23 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeDeleteController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String idStr = request.getParameter("id");
+        if (idStr != null) {
+            int id = Integer.parseInt(idStr);
+            measurementTypeDAO.delete(id);
+        }
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
@@ -1,0 +1,22 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+public class MeasurementTypeListController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<MeasurementType> list = measurementTypeDAO.findAll();
+        request.setAttribute("measurementTypes", list);
+        request.getRequestDispatcher("/jsp/measurementtype/listMeasurementType.jsp").forward(request, response);
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeUpdateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeUpdateController.java
@@ -1,0 +1,40 @@
+package controller.measurementtype;
+
+import dao.measurementtype.MeasurementTypeDAO;
+import model.MeasurementType;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MeasurementTypeUpdateController extends HttpServlet {
+    private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String idStr = request.getParameter("id");
+        if (idStr != null) {
+            int id = Integer.parseInt(idStr);
+            MeasurementType mt = measurementTypeDAO.findById(id);
+            request.setAttribute("measurementType", mt);
+            request.getRequestDispatcher("/jsp/measurementtype/updateMeasurementType.jsp").forward(request, response);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/measurement-types");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        int id = Integer.parseInt(request.getParameter("id"));
+        String name = request.getParameter("name");
+        String unit = request.getParameter("unit");
+        MeasurementType mt = new MeasurementType();
+        mt.setId(id);
+        mt.setName(name);
+        mt.setUnit(unit);
+        measurementTypeDAO.update(mt);
+        response.sendRedirect(request.getContextPath() + "/measurement-types");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderHistoryController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderHistoryController.java
@@ -1,0 +1,28 @@
+package controller.order;
+
+import dao.order.OrderDAO;
+import model.OrderDetail;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+public class OrderHistoryController extends HttpServlet {
+    private final OrderDAO orderDAO = new OrderDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String idStr = request.getParameter("id");
+        if (idStr == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        int customerId = Integer.parseInt(idStr);
+        List<OrderDetail> details = orderDAO.findDetailsByCustomer(customerId);
+        request.setAttribute("details", details);
+        request.getRequestDispatcher("/jsp/order/customerOrderHistory.jsp").forward(request, response);
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/dao/customer/CustomerDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/customer/CustomerDAO.java
@@ -12,7 +12,7 @@ public class CustomerDAO {
     public List<Customer> findAll() {
         List<Customer> list = new ArrayList<>();
         // Table khach_hang stores customer information
-        String sql = "SELECT ma_khach, ho_ten, so_dien_thoai, email FROM khach_hang";
+        String sql = "SELECT ma_khach, ho_ten, so_dien_thoai, email, ngay_tao FROM khach_hang";
         try (Connection conn = DBConnect.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
@@ -22,6 +22,7 @@ public class CustomerDAO {
                 c.setName(rs.getString("ho_ten"));
                 c.setPhone(rs.getString("so_dien_thoai"));
                 c.setEmail(rs.getString("email"));
+                c.setCreatedAt(rs.getTimestamp("ngay_tao"));
                 list.add(c);
             }
         } catch (SQLException e) {
@@ -44,7 +45,7 @@ public class CustomerDAO {
     }
 
     public Customer findById(int id) {
-        String sql = "SELECT ma_khach, ho_ten, so_dien_thoai, email FROM khach_hang WHERE ma_khach=?";
+        String sql = "SELECT ma_khach, ho_ten, so_dien_thoai, email, ngay_tao FROM khach_hang WHERE ma_khach=?";
         try (Connection conn = DBConnect.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
@@ -55,6 +56,7 @@ public class CustomerDAO {
                     c.setName(rs.getString("ho_ten"));
                     c.setPhone(rs.getString("so_dien_thoai"));
                     c.setEmail(rs.getString("email"));
+                    c.setCreatedAt(rs.getTimestamp("ngay_tao"));
                     return c;
                 }
             }

--- a/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurementtype/MeasurementTypeDAO.java
@@ -26,4 +26,60 @@ public class MeasurementTypeDAO {
         }
         return list;
     }
+
+    public void insert(MeasurementType mt) {
+        String sql = "INSERT INTO loai_thong_so(ten_thong_so, don_vi) VALUES(?,?)";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, mt.getName());
+            ps.setString(2, mt.getUnit());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public MeasurementType findById(int id) {
+        String sql = "SELECT ma_thong_so, ten_thong_so, don_vi FROM loai_thong_so WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    MeasurementType mt = new MeasurementType();
+                    mt.setId(rs.getInt("ma_thong_so"));
+                    mt.setName(rs.getString("ten_thong_so"));
+                    mt.setUnit(rs.getString("don_vi"));
+                    return mt;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public void update(MeasurementType mt) {
+        String sql = "UPDATE loai_thong_so SET ten_thong_so = ?, don_vi = ? WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, mt.getName());
+            ps.setString(2, mt.getUnit());
+            ps.setInt(3, mt.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void delete(int id) {
+        String sql = "DELETE FROM loai_thong_so WHERE ma_thong_so = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -2,6 +2,7 @@ package dao.order;
 
 import dao.connect.DBConnect;
 import model.Order;
+import model.OrderDetail;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -69,5 +70,31 @@ public class OrderDAO {
         } catch (SQLException e) {
             e.printStackTrace();
         }
+    }
+
+    public List<OrderDetail> findDetailsByCustomer(int customerId) {
+        List<OrderDetail> list = new ArrayList<>();
+        String sql = "SELECT ct.ma_ct, ct.ma_don, ct.loai_sp, ct.ten_vai, ct.don_gia, ct.so_luong, ct.ghi_chu " +
+                     "FROM chi_tiet_don ct JOIN don_hang dh ON ct.ma_don = dh.ma_don WHERE dh.ma_khach = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, customerId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    OrderDetail d = new OrderDetail();
+                    d.setId(rs.getInt("ma_ct"));
+                    d.setOrderId(rs.getInt("ma_don"));
+                    d.setProductType(rs.getString("loai_sp"));
+                    d.setMaterialName(rs.getString("ten_vai"));
+                    d.setUnitPrice(rs.getDouble("don_gia"));
+                    d.setQuantity(rs.getInt("so_luong"));
+                    d.setNote(rs.getString("ghi_chu"));
+                    list.add(d);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
     }
 }

--- a/TailorSoft_COCOLAND/src/java/model/Customer.java
+++ b/TailorSoft_COCOLAND/src/java/model/Customer.java
@@ -5,15 +5,21 @@ public class Customer {
     private String name;
     private String phone;
     private String email;
+    private java.util.Date createdAt;
 
     public Customer() {
     }
 
     public Customer(int id, String name, String phone, String email) {
+        this(id, name, phone, email, null);
+    }
+
+    public Customer(int id, String name, String phone, String email, java.util.Date createdAt) {
         this.id = id;
         this.name = name;
         this.phone = phone;
         this.email = email;
+        this.createdAt = createdAt;
     }
 
     public int getId() {
@@ -46,5 +52,13 @@ public class Customer {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public java.util.Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(java.util.Date createdAt) {
+        this.createdAt = createdAt;
     }
 }

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -79,6 +79,15 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>OrderHistoryController</servlet-name>
+        <servlet-class>controller.order.OrderHistoryController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>OrderHistoryController</servlet-name>
+        <url-pattern>/customers/history</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>MeasurementListController</servlet-name>
         <servlet-class>controller.measurement.MeasurementListController</servlet-class>
     </servlet>
@@ -94,6 +103,42 @@
     <servlet-mapping>
         <servlet-name>MeasurementCreateController</servlet-name>
         <url-pattern>/measurements/create</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeListController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeListController</servlet-name>
+        <url-pattern>/measurement-types</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeCreateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeCreateController</servlet-name>
+        <url-pattern>/measurement-types/create</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeUpdateController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeUpdateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeUpdateController</servlet-name>
+        <url-pattern>/measurement-types/update</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>MeasurementTypeDeleteController</servlet-name>
+        <servlet-class>controller.measurementtype.MeasurementTypeDeleteController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementTypeDeleteController</servlet-name>
+        <url-pattern>/measurement-types/delete</url-pattern>
     </servlet-mapping>
 
     <servlet>

--- a/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
@@ -13,7 +13,9 @@
         <th>Họ tên</th>
         <th>Số điện thoại</th>
         <th>Email</th>
-        <th></th>
+        <th>Ngày tạo</th>
+        <th>Lịch sử đặt may</th>
+        <th>Sửa</th>
     </tr>
     <c:forEach var="c" items="${customers}">
         <tr>
@@ -21,6 +23,8 @@
             <td>${c.name}</td>
             <td>${c.phone}</td>
             <td>${c.email}</td>
+            <td>${c.createdAt}</td>
+            <td><a href="<c:url value='/customers/history?id=${c.id}'/>">Xem lịch sử</a></td>
             <td><a href="<c:url value='/customers/update?id=${c.id}'/>">Sửa</a></td>
         </tr>
     </c:forEach>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/createMeasurementType.jsp
@@ -1,0 +1,15 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Thêm loại số đo</title>
+</head>
+<body>
+<h2>Thêm loại số đo</h2>
+<form action="<c:url value='/measurement-types/create'/>" method="post">
+    Tên thông số: <input type="text" name="name"/><br/>
+    Đơn vị: <input type="text" name="unit" value="cm"/><br/>
+    <input type="submit" value="Lưu"/>
+</form>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
@@ -1,0 +1,29 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Danh sách loại số đo</title>
+</head>
+<body>
+<h2>Danh sách loại số đo</h2>
+<a href="<c:url value='/measurement-types/create'/>">Thêm loại số đo</a>
+<table border="1">
+    <tr>
+        <th>Mã</th>
+        <th>Tên thông số</th>
+        <th>Đơn vị</th>
+        <th>Sửa</th>
+        <th>Xóa</th>
+    </tr>
+    <c:forEach var="mt" items="${measurementTypes}">
+        <tr>
+            <td>${mt.id}</td>
+            <td>${mt.name}</td>
+            <td>${mt.unit}</td>
+            <td><a href="<c:url value='/measurement-types/update?id=${mt.id}'/>">Sửa</a></td>
+            <td><a href="<c:url value='/measurement-types/delete?id=${mt.id}'/>" onclick="return confirm('Bạn có chắc muốn xóa?');">Xóa</a></td>
+        </tr>
+    </c:forEach>
+</table>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/updateMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/updateMeasurementType.jsp
@@ -1,0 +1,16 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Cập nhật loại số đo</title>
+</head>
+<body>
+<h2>Cập nhật loại số đo</h2>
+<form action="<c:url value='/measurement-types/update'/>" method="post">
+    <input type="hidden" name="id" value="${measurementType.id}"/>
+    Tên thông số: <input type="text" name="name" value="${measurementType.name}"/><br/>
+    Đơn vị: <input type="text" name="unit" value="${measurementType.unit}"/><br/>
+    <input type="submit" value="Cập nhật"/>
+</form>
+</body>
+</html>

--- a/TailorSoft_COCOLAND/web/jsp/order/customerOrderHistory.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/customerOrderHistory.jsp
@@ -1,0 +1,22 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Lịch sử đặt may</title>
+</head>
+<body>
+<h2>Lịch sử đặt may</h2>
+<table border="1">
+    <tr>
+        <th>Sản phẩm</th>
+        <th>Chi tiết</th>
+    </tr>
+    <c:forEach var="d" items="${details}">
+        <tr>
+            <td>${d.productType}</td>
+            <td><a href="<c:url value='/orders/detail?id=${d.orderId}'/>">Xem chi tiết đơn hàng</a></td>
+        </tr>
+    </c:forEach>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support creating, listing, updating, and deleting measurement types
- wire up measurement type update and delete controllers in web.xml
- document measurement type catalog management and clarify customer order history behavior
- standardize edit and delete links in the measurement type list JSP
- use `<c:url>` in measurement type creation and update forms for consistent URL handling
- show customer creation dates and link to tailoring history
- list each customer's orders by product type with access to order detail

## Testing
- `apt-get install -y ant`
- `ant -q -f TailorSoft_COCOLAND/build.xml compile`


------
https://chatgpt.com/codex/tasks/task_b_688d161f4b7c83229d64c7010f7603d1