### PR TITLE
Add pagination for all list pages

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/customer/CustomerListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/customer/CustomerListController.java
@@ -13,11 +13,27 @@ import java.util.List;
 public class CustomerListController extends HttpServlet {
 
     private final CustomerDAO customerDAO = new CustomerDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Customer> customers = customerDAO.findAll();
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<Customer> all = customerDAO.findAll();
+        int total = all.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<Customer> customers = all.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         request.setAttribute("customers", customers);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         String msg = request.getParameter("msg");
         if (msg != null) {
             request.setAttribute("msg", msg);

--- a/TailorSoft_COCOLAND/src/java/controller/material/MaterialListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/material/MaterialListController.java
@@ -12,11 +12,27 @@ import java.util.List;
 
 public class MaterialListController extends HttpServlet {
     private final MaterialDAO materialDAO = new MaterialDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Material> materials = materialDAO.findAll();
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<Material> all = materialDAO.findAll();
+        int total = all.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<Material> materials = all.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         request.setAttribute("materials", materials);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         String msg = request.getParameter("msg");
         if (msg != null) {
             request.setAttribute("msg", msg);

--- a/TailorSoft_COCOLAND/src/java/controller/measurement/MeasurementListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurement/MeasurementListController.java
@@ -12,11 +12,27 @@ import java.util.List;
 
 public class MeasurementListController extends HttpServlet {
     private final MeasurementDAO measurementDAO = new MeasurementDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Measurement> list = measurementDAO.findAll();
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<Measurement> all = measurementDAO.findAll();
+        int total = all.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<Measurement> list = all.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         request.setAttribute("measurements", list);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         request.getRequestDispatcher("/jsp/measurement/listMeasurement.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/measurementtype/MeasurementTypeListController.java
@@ -12,15 +12,31 @@ import java.util.List;
 
 public class MeasurementTypeListController extends HttpServlet {
     private final MeasurementTypeDAO measurementTypeDAO = new MeasurementTypeDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String bodyPart = request.getParameter("bodyPart");
         String q = request.getParameter("q");
-        List<MeasurementType> list = measurementTypeDAO.search(bodyPart, q);
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<MeasurementType> all = measurementTypeDAO.search(bodyPart, q);
+        int total = all.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<MeasurementType> list = all.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         List<String> bodyParts = measurementTypeDAO.findBodyParts();
         request.setAttribute("measurementTypes", list);
         request.setAttribute("bodyParts", bodyParts);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         request.getRequestDispatcher("/jsp/measurementtype/listMeasurementType.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderHistoryController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderHistoryController.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class OrderHistoryController extends HttpServlet {
     private final OrderDAO orderDAO = new OrderDAO();
     private final CustomerDAO customerDAO = new CustomerDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -29,16 +30,30 @@ public class OrderHistoryController extends HttpServlet {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
-        List<Order> orders = orderDAO.findByCustomer(customerId);
-        int total = orders.size();
-        long pending = orders.stream()
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<Order> allOrders = orderDAO.findByCustomer(customerId);
+        int total = allOrders.size();
+        long pending = allOrders.stream()
                 .filter(o -> o.getStatus() == null || !"Hoàn thành".equalsIgnoreCase(o.getStatus()))
                 .count();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<Order> orders = allOrders.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         request.setAttribute("customer", customer);
         request.setAttribute("orders", orders);
         request.setAttribute("totalOrders", total);
         request.setAttribute("pendingOrders", pending);
         request.setAttribute("completedOrders", total - pending);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         request.getRequestDispatcher("/jsp/order/customerOrderHistory.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderListController.java
@@ -15,11 +15,27 @@ import java.util.List;
 public class OrderListController extends HttpServlet {
     private final OrderDAO orderDAO = new OrderDAO();
     private final CustomerDAO customerDAO = new CustomerDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Order> orders = orderDAO.findAll();
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<Order> allOrders = orderDAO.findAll();
+        int total = allOrders.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<Order> orders = allOrders.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         request.setAttribute("orders", orders);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         List<Customer> customers = customerDAO.findAll();
         request.setAttribute("customers", customers);
         String msg = request.getParameter("msg");

--- a/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeListController.java
@@ -15,16 +15,32 @@ import java.util.HashMap;
 
 public class ProductTypeListController extends HttpServlet {
     private final ProductTypeDAO productTypeDAO = new ProductTypeDAO();
+    private static final int PAGE_SIZE = 10;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<ProductType> list = productTypeDAO.findAll();
+        int page = 1;
+        String pageParam = request.getParameter("page");
+        if (pageParam != null) {
+            try {
+                page = Integer.parseInt(pageParam);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        List<ProductType> all = productTypeDAO.findAll();
+        int total = all.size();
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        int to = Math.min(from + PAGE_SIZE, total);
+        List<ProductType> list = all.subList(from, to);
+        int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
         Map<Integer, List<MeasurementType>> map = new HashMap<>();
         for (ProductType pt : list) {
             map.put(pt.getId(), productTypeDAO.findMeasurementTypes(pt.getId()));
         }
         request.setAttribute("productTypes", list);
         request.setAttribute("productMeasurements", map);
+        request.setAttribute("currentPage", page);
+        request.setAttribute("totalPages", totalPages);
         request.getRequestDispatcher("/jsp/producttype/listProductType.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/web/jsp/common/pagination.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/common/pagination.jsp
@@ -1,0 +1,21 @@
+<%@ page pageEncoding="UTF-8" contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:set var="extraParams" value="" />
+<c:forEach var="entry" items="${paramValues}">
+    <c:if test="${entry.key ne 'page'}">
+        <c:forEach var="val" items="${entry.value}">
+            <c:set var="extraParams" value="${extraParams}&${entry.key}=${val}" />
+        </c:forEach>
+    </c:if>
+</c:forEach>
+<c:if test="${totalPages > 1}">
+<nav aria-label="Page navigation">
+    <ul class="pagination">
+        <c:forEach begin="1" end="${totalPages}" var="i">
+            <li class="page-item ${i == currentPage ? 'active' : ''}">
+                <a class="page-link" href="?page=${i}${extraParams}">${i}</a>
+            </li>
+        </c:forEach>
+    </ul>
+</nav>
+</c:if>

--- a/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
@@ -71,6 +71,7 @@
     </c:forEach>
     </tbody>
 </table>
+<jsp:include page="/jsp/common/pagination.jsp"/>
 
 <!-- Modal cập nhật khách hàng -->
 <div class="modal fade" id="editCustomerModal" tabindex="-1" aria-hidden="true">

--- a/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
@@ -52,6 +52,7 @@
     </c:forEach>
     </tbody>
 </table>
+<jsp:include page="/jsp/common/pagination.jsp"/>
 <script>
     document.getElementById('materialSearch').addEventListener('keyup', function () {
         const filter = this.value.toLowerCase();

--- a/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
@@ -33,6 +33,7 @@
             </c:forEach>
             </tbody>
         </table>
+        <jsp:include page="/jsp/common/pagination.jsp"/>
     </div>
 </div>
 <jsp:include page="/jsp/common/footer.jsp"/>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
@@ -52,6 +52,7 @@
                 </c:forEach>
             </tbody>
         </table>
+        <jsp:include page="/jsp/common/pagination.jsp"/>
     </div>
 </div>
 <jsp:include page="/jsp/common/footer.jsp"/>

--- a/TailorSoft_COCOLAND/web/jsp/order/customerOrderHistory.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/customerOrderHistory.jsp
@@ -44,6 +44,7 @@
             </c:forEach>
             </tbody>
         </table>
+        <jsp:include page="/jsp/common/pagination.jsp"/>
     </div>
 </div>
 <script>

--- a/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
@@ -84,6 +84,7 @@
             </c:forEach>
             </tbody>
         </table>
+        <jsp:include page="/jsp/common/pagination.jsp"/>
         <script>
             function applyFilters() {
                 const search = document.getElementById('orderSearch').value.toLowerCase();

--- a/TailorSoft_COCOLAND/web/jsp/producttype/listProductType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/producttype/listProductType.jsp
@@ -35,6 +35,7 @@
                 </c:forEach>
             </tbody>
         </table>
+        <jsp:include page="/jsp/common/pagination.jsp"/>
     </div>
 </div>
 <jsp:include page="/jsp/common/footer.jsp"/>


### PR DESCRIPTION
## Summary
- add shared JSP snippet for rendering pagination links
- paginate customer, material, measurement, measurement type, order, product type and history controllers
- include pagination in each list view

## Testing
- `ant compile`
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_688f916b7e4483229c5baf7c11e93442