### PR TITLE
Add popup viewer for material invoice images

### DIFF
--- a/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
@@ -45,7 +45,8 @@
             <td class="text-end"><fmt:formatNumber value="${m.quantity}" type="number" pattern="#,##0.##"/> m</td>
             <td>
                 <c:if test="${not empty m.invoiceImage}">
-                    <img src="<c:url value='/uploads/${m.invoiceImage}'/>" alt="Hóa đơn" style="height:40px;">
+                    <img src="<c:url value='/uploads/${m.invoiceImage}'/>" alt="Hóa đơn" style="height:40px;" class="me-2">
+                    <button type="button" class="btn btn-sm btn-secondary" onclick="showInvoice('<c:url value='/uploads/${m.invoiceImage}'/>')">Xem ảnh</button>
                 </c:if>
             </td>
         </tr>
@@ -61,6 +62,26 @@
             row.style.display = text.indexOf(filter) > -1 ? '' : 'none';
         });
     });
+</script>
+<div class="modal fade" id="invoiceModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Hóa đơn</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-center">
+                <img id="invoiceModalImage" src="" alt="Hóa đơn" class="img-fluid"/>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    function showInvoice(src) {
+        document.getElementById('invoiceModalImage').src = src;
+        const modal = new bootstrap.Modal(document.getElementById('invoiceModal'));
+        modal.show();
+    }
 </script>
 <c:if test="${not empty msg}">
     <script>


### PR DESCRIPTION
## Summary
- add "Xem ảnh" button beside invoice thumbnails to open a larger preview
- implement Bootstrap modal and JS helper to display selected invoice image

## Testing
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_688fa7f970548322876ea005081238ff