### PR TITLE
Show order products in detail page

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
@@ -2,12 +2,14 @@ package controller.order;
 
 import dao.order.OrderDAO;
 import model.Order;
+import model.OrderDetail;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 public class OrderDetailController extends HttpServlet {
     private final OrderDAO orderDAO = new OrderDAO();
@@ -25,7 +27,9 @@ public class OrderDetailController extends HttpServlet {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
+        List<OrderDetail> details = orderDAO.findDetailsByOrder(id);
         request.setAttribute("order", order);
+        request.setAttribute("details", details);
         request.getRequestDispatcher("/jsp/order/orderDetail.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -102,6 +102,31 @@ public class OrderDAO {
         }
     }
 
+    public List<OrderDetail> findDetailsByOrder(int orderId) {
+        List<OrderDetail> list = new ArrayList<>();
+        String sql = "SELECT ma_ct, ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu FROM chi_tiet_don WHERE ma_don = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, orderId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    OrderDetail d = new OrderDetail();
+                    d.setId(rs.getInt("ma_ct"));
+                    d.setOrderId(rs.getInt("ma_don"));
+                    d.setProductType(rs.getString("loai_sp"));
+                    d.setMaterialName(rs.getString("ten_vai"));
+                    d.setUnitPrice(rs.getDouble("don_gia"));
+                    d.setQuantity(rs.getInt("so_luong"));
+                    d.setNote(rs.getString("ghi_chu"));
+                    list.add(d);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
     public List<OrderDetail> findDetailsByCustomer(int customerId) {
         List<OrderDetail> list = new ArrayList<>();
         String sql = "SELECT ct.ma_ct, ct.ma_don, ct.loai_sp, ct.ten_vai, ct.don_gia, ct.so_luong, ct.ghi_chu " +

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -26,6 +26,30 @@
                     </div>
                 </div>
             </div>
+            <c:if test="${not empty details}">
+                <table class="table table-striped mb-4">
+                    <thead>
+                    <tr>
+                        <th>Sản phẩm</th>
+                        <th>Tên vải</th>
+                        <th>Đơn giá</th>
+                        <th>Số lượng</th>
+                        <th>Ghi chú</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="d" items="${details}">
+                        <tr>
+                            <td>${d.productType}</td>
+                            <td>${d.materialName}</td>
+                            <td><fmt:formatNumber value="${d.unitPrice}" type="number" groupingUsed="true"/> ₫</td>
+                            <td>${d.quantity}</td>
+                            <td>${d.note}</td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </c:if>
             <div class="d-flex gap-2 mb-3">
                 <a href="#" class="btn btn-outline-primary btn-sm"><i class="fa fa-pen"></i> Cập nhật trạng thái</a>
                 <a href="#" class="btn btn-outline-success btn-sm"><i class="fa fa-coins"></i> Thêm thanh toán</a>


### PR DESCRIPTION
## Summary
- load order line items when viewing an order
- display product details table on order detail page
- add DAO helper to fetch order detail records

## Testing
- `ant test`

------
https://chatgpt.com/codex/tasks/task_b_688fa838a4dc832289d3699f2d8d8e86