### PR TITLE
Replace ID columns with STT numbers

### DIFF
--- a/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/customer/listCustomer.jsp
@@ -41,7 +41,7 @@
 <table id="customerTable" class="table table-striped table-hover">
     <thead>
     <tr>
-        <th>#</th>
+        <th>STT</th>
         <th>Họ tên</th>
         <th>Số điện thoại</th>
         <th>Email</th>

--- a/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/material/listMaterial.jsp
@@ -25,7 +25,7 @@
 <table id="materialTable" class="table table-striped table-hover">
     <thead class="table-dark">
     <tr>
-        <th>Mã</th>
+        <th>STT</th>
         <th>Tên vải</th>
         <th>Màu sắc</th>
         <th>Xuất xứ</th>
@@ -35,9 +35,9 @@
     </tr>
     </thead>
     <tbody>
-    <c:forEach var="m" items="${materials}">
+    <c:forEach var="m" items="${materials}" varStatus="status">
         <tr class="${m.quantity < lowStockThreshold ? 'table-danger' : ''}">
-            <td>${m.id}</td>
+            <td>${status.index + 1}</td>
             <td>${m.name}</td>
             <td class="text-truncate" style="max-width:150px;">${m.color}</td>
             <td>${m.origin}</td>

--- a/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
@@ -12,7 +12,7 @@
         <table class="table table-striped table-hover">
             <thead class="table-dark">
             <tr>
-                <th>Mã</th>
+                <th>STT</th>
                 <th>Khách hàng</th>
                 <th>Loại sản phẩm</th>
                 <th>Thông số</th>
@@ -21,9 +21,9 @@
             </tr>
             </thead>
             <tbody>
-            <c:forEach var="m" items="${measurements}">
+            <c:forEach var="m" items="${measurements}" varStatus="status">
                 <tr>
-                    <td>${m.id}</td>
+                    <td>${status.index + 1}</td>
                     <td>${m.customerName}</td>
                     <td>${m.productTypeName}</td>
                     <td>${m.measurementTypeName}</td>

--- a/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurementtype/listMeasurementType.jsp
@@ -28,7 +28,7 @@
         <table class="table table-striped">
             <thead class="table-dark">
                 <tr>
-                    <th>#</th>
+                    <th>STT</th>
                     <th>Tên số đo</th>
                     <th>Bộ phận</th>
                     <th>Đơn vị</th>
@@ -37,9 +37,9 @@
                 </tr>
             </thead>
             <tbody>
-                <c:forEach var="mt" items="${measurementTypes}">
+                <c:forEach var="mt" items="${measurementTypes}" varStatus="st">
                     <tr>
-                        <td>${mt.id}</td>
+                        <td>${st.index + 1}</td>
                         <td>${mt.name}</td>
                         <td>${mt.bodyPart}</td>
                         <td>${mt.unit}</td>

--- a/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
@@ -47,7 +47,8 @@
         <table id="orderTable" class="table table-striped table-hover">
             <thead>
             <tr>
-                <th class="d-none">Mã</th>
+                <th>STT</th>
+                <th class="d-none">ID</th>
                 <th>Khách hàng</th>
                 <th>Ngày đặt</th>
                 <th>Ngày giao</th>
@@ -59,9 +60,10 @@
             </tr>
             </thead>
             <tbody>
-            <c:forEach var="o" items="${orders}">
+            <c:forEach var="o" items="${orders}" varStatus="st">
                 <c:set var="orderMonth"><fmt:formatDate value="${o.orderDate}" pattern="yyyy-MM"/></c:set>
                 <tr data-status="${o.status}" data-order-date="${orderMonth}" data-customer-id="${o.customerId}">
+                    <td>${st.index + 1}</td>
                     <td class="d-none">${o.id}</td>
                     <td><span data-bs-toggle="tooltip" title="${o.customerPhone} / ${o.customerEmail}">${o.customerName}</span></td>
                     <td><fmt:formatDate value="${o.orderDate}" pattern="dd-MM-yyyy"/></td>

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -12,7 +12,6 @@
                 <div class="card-body">
                     <div class="row">
                         <div class="col-md-6">
-                            <p><strong>Mã:</strong> ${order.id}</p>
                             <p><strong>Khách hàng:</strong> ${order.customerName}</p>
                             <p><strong>Ngày đặt:</strong> <fmt:formatDate value="${order.orderDate}" pattern="dd-MM-yyyy"/></p>
                             <p><strong>Ngày giao:</strong> <fmt:formatDate value="${order.deliveryDate}" pattern="dd-MM-yyyy"/></p>

--- a/TailorSoft_COCOLAND/web/jsp/producttype/listProductType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/producttype/listProductType.jsp
@@ -12,7 +12,7 @@
         <table class="table table-striped">
             <thead class="table-dark">
                 <tr>
-                    <th>Mã</th>
+                    <th>STT</th>
                     <th>Tên loại</th>
                     <th>Ký hiệu</th>
                     <th>Số đo áp dụng</th>
@@ -20,9 +20,9 @@
                 </tr>
             </thead>
             <tbody>
-                <c:forEach var="pt" items="${productTypes}">
+                <c:forEach var="pt" items="${productTypes}" varStatus="status">
                     <tr>
-                        <td>${pt.id}</td>
+                        <td>${status.index + 1}</td>
                         <td>${pt.name}</td>
                         <td>${pt.code}</td>
                         <td>


### PR DESCRIPTION
## Summary
- add STT column to measurement type list using loop index
- show sequential numbers for order listing and remove order ID from detail page
- rename customer list column header to STT

## Testing
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_688fb2bd7530832297cd8eb288feefc8