### PR TITLE
Preserve order context when creating related entities

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/customer/CustomerCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/customer/CustomerCreateController.java
@@ -26,6 +26,11 @@ public class CustomerCreateController extends HttpServlet {
         String address = request.getParameter("address");
         Customer c = new Customer(0, name, phone, email, address);
         customerDAO.insert(c);
-        response.sendRedirect(request.getContextPath() + "/customers?msg=created");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/customers?msg=created");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/material/MaterialCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/material/MaterialCreateController.java
@@ -44,6 +44,11 @@ public class MaterialCreateController extends HttpServlet {
 
         Material m = new Material(0, name, color, origin, price, quantity, fileName);
         materialDAO.insert(m);
-        response.sendRedirect(request.getContextPath() + "/materials?msg=created");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/materials?msg=created");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeCreateController.java
@@ -40,6 +40,11 @@ public class ProductTypeCreateController extends HttpServlet {
         pt.setName(name);
         pt.setCode(code);
         productTypeDAO.insert(pt, ids);
-        response.sendRedirect(request.getContextPath() + "/product-types");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/product-types");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/web/jsp/customer/createCustomer.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/customer/createCustomer.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
 <h2>Thêm khách hàng</h2>
 <form action="" method="post">
+    <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
     <div class="mb-3">
         <label class="form-label">Họ tên</label>
         <input type="text" name="name" class="form-control" required/>

--- a/TailorSoft_COCOLAND/web/jsp/material/createMaterial.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/material/createMaterial.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
 <h2>Thêm vải</h2>
 <form action="" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
     <div class="row">
         <div class="col-md-6">
             <div class="mb-3">

--- a/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
@@ -31,7 +31,10 @@
                                 <option value="${c.id}">${c.name} - ${c.phone}</option>
                             </c:forEach>
                         </select>
-                        <div class="form-text"><a href="<c:url value='/customers/create'/>" target="_blank">Thêm khách mới</a></div>
+                        <c:url var="customerCreateUrl" value="/customers/create">
+                            <c:param name="returnUrl" value="/orders/create"/>
+                        </c:url>
+                        <div class="form-text"><a href="${customerCreateUrl}">Thêm khách mới</a></div>
                     </div>
                 </div>
                 <div class="tab-pane fade" id="step2" role="tabpanel">
@@ -53,6 +56,10 @@
                                                 <option value="${pt.id}">${pt.name}</option>
                                             </c:forEach>
                                         </select>
+                                        <c:url var="ptCreateUrl" value="/product-types/create">
+                                            <c:param name="returnUrl" value="/orders/create"/>
+                                        </c:url>
+                                        <div class="form-text"><a href="${ptCreateUrl}">Thêm loại sản phẩm</a></div>
                                     </div>
                                     <div class="col-md-2">
                                         <label class="form-label">Số lượng</label>
@@ -74,7 +81,10 @@
                             <label class="form-label">Chọn vải</label>
                             <div id="materialsContainer"></div>
                             <button type="button" class="btn btn-outline-primary mt-2" id="addMaterialBtn">+ Thêm vải khác</button>
-                            <div class="form-text"><a href="<c:url value='/materials/create'/>" target="_blank">Thêm vải mới</a></div>
+                            <c:url var="materialCreateUrl" value="/materials/create">
+                                <c:param name="returnUrl" value="/orders/create"/>
+                            </c:url>
+                            <div class="form-text"><a href="${materialCreateUrl}">Thêm vải mới</a></div>
                             <template id="materialTemplate">
                                 <div class="input-group mb-2">
                                     <select class="form-select" name="materialId__INDEX__" required>

--- a/TailorSoft_COCOLAND/web/jsp/producttype/createProductType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/producttype/createProductType.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
         <h2>Thêm loại sản phẩm may</h2>
         <form action="" method="post" id="productTypeForm" class="mt-3">
+            <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
             <div class="mb-3">
                 <label class="form-label">Tên loại sản phẩm</label>
                 <input type="text" name="name" class="form-control" required>


### PR DESCRIPTION
## Summary
- Ensure "Add customer", "Add product type" and "Add fabric" links on the order form return to the ongoing order instead of opening new tabs by using redirect URLs.
- Include hidden `returnUrl` fields in customer, product type and material creation forms so completed creations bounce back to the order page.
- Controllers now honor the optional `returnUrl` parameter and redirect accordingly after saving.

## Testing
- `javac -cp "lib/*:src/java" src/java/controller/customer/CustomerCreateController.java src/java/controller/material/MaterialCreateController.java src/java/controller/producttype/ProductTypeCreateController.java`
- `ant compile` *(fails: ant not installed; package installation reported ca-certificates-java error)*


------
https://chatgpt.com/codex/tasks/task_b_688fb377e7488322b86df29d37f1b773