### PR TITLE
Preserve order context when creating related entities and add product picker

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/customer/CustomerCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/customer/CustomerCreateController.java
@@ -26,6 +26,11 @@ public class CustomerCreateController extends HttpServlet {
         String address = request.getParameter("address");
         Customer c = new Customer(0, name, phone, email, address);
         customerDAO.insert(c);
-        response.sendRedirect(request.getContextPath() + "/customers?msg=created");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/customers?msg=created");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/material/MaterialCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/material/MaterialCreateController.java
@@ -44,6 +44,11 @@ public class MaterialCreateController extends HttpServlet {
 
         Material m = new Material(0, name, color, origin, price, quantity, fileName);
         materialDAO.insert(m);
-        response.sendRedirect(request.getContextPath() + "/materials?msg=created");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/materials?msg=created");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeCreateController.java
@@ -40,6 +40,11 @@ public class ProductTypeCreateController extends HttpServlet {
         pt.setName(name);
         pt.setCode(code);
         productTypeDAO.insert(pt, ids);
-        response.sendRedirect(request.getContextPath() + "/product-types");
+        String returnUrl = request.getParameter("returnUrl");
+        if (returnUrl != null && !returnUrl.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + returnUrl);
+        } else {
+            response.sendRedirect(request.getContextPath() + "/product-types");
+        }
     }
 }

--- a/TailorSoft_COCOLAND/web/jsp/customer/createCustomer.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/customer/createCustomer.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
 <h2>Thêm khách hàng</h2>
 <form action="" method="post">
+    <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
     <div class="mb-3">
         <label class="form-label">Họ tên</label>
         <input type="text" name="name" class="form-control" required/>

--- a/TailorSoft_COCOLAND/web/jsp/material/createMaterial.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/material/createMaterial.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
 <h2>Thêm vải</h2>
 <form action="" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
     <div class="row">
         <div class="col-md-6">
             <div class="mb-3">

--- a/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
@@ -31,12 +31,15 @@
                                 <option value="${c.id}">${c.name} - ${c.phone}</option>
                             </c:forEach>
                         </select>
-                        <div class="form-text"><a href="<c:url value='/customers/create'/>" target="_blank">Thêm khách mới</a></div>
+                        <c:url var="customerCreateUrl" value="/customers/create">
+                            <c:param name="returnUrl" value="/orders/create"/>
+                        </c:url>
+                        <div class="form-text"><a href="${customerCreateUrl}">Thêm khách mới</a></div>
                     </div>
                 </div>
                 <div class="tab-pane fade" id="step2" role="tabpanel">
                     <div id="itemsContainer">
-                        <button type="button" class="btn btn-outline-primary mt-2" id="addItemBtn">+ Thêm sản phẩm khác</button>
+                        <button type="button" class="btn btn-outline-primary mt-2" id="addItemBtn">+ Chọn sản phẩm</button>
                     </div>
                     <template id="itemTemplate">
                         <div class="card mb-3">
@@ -53,6 +56,10 @@
                                                 <option value="${pt.id}">${pt.name}</option>
                                             </c:forEach>
                                         </select>
+                                        <c:url var="ptCreateUrl" value="/product-types/create">
+                                            <c:param name="returnUrl" value="/orders/create"/>
+                                        </c:url>
+                                        <div class="form-text"><a href="${ptCreateUrl}">Thêm loại sản phẩm</a></div>
                                     </div>
                                     <div class="col-md-2">
                                         <label class="form-label">Số lượng</label>
@@ -74,7 +81,10 @@
                             <label class="form-label">Chọn vải</label>
                             <div id="materialsContainer"></div>
                             <button type="button" class="btn btn-outline-primary mt-2" id="addMaterialBtn">+ Thêm vải khác</button>
-                            <div class="form-text"><a href="<c:url value='/materials/create'/>" target="_blank">Thêm vải mới</a></div>
+                            <c:url var="materialCreateUrl" value="/materials/create">
+                                <c:param name="returnUrl" value="/orders/create"/>
+                            </c:url>
+                            <div class="form-text"><a href="${materialCreateUrl}">Thêm vải mới</a></div>
                             <template id="materialTemplate">
                                 <div class="input-group mb-2">
                                     <select class="form-select" name="materialId__INDEX__" required>
@@ -145,6 +155,11 @@
 
     const mtUrl = '<c:url value="/product-types/measurement-types"/>';
     let itemIndex = 0;
+    const addItemBtn = document.getElementById('addItemBtn');
+    function updateAddItemBtn(){
+        const hasItem = document.querySelectorAll('#itemsContainer .card').length > 0;
+        addItemBtn.textContent = hasItem ? '+ Thêm sản phẩm khác' : '+ Chọn sản phẩm';
+    }
     function addItem(){
         const idx = itemIndex;
         const tpl = document.getElementById('itemTemplate').innerHTML.replace(/__INDEX__/g, idx);
@@ -152,8 +167,8 @@
         div.innerHTML = tpl;
         const item = div.firstElementChild;
         const container = document.getElementById('itemsContainer');
-        container.insertBefore(item, document.getElementById('addItemBtn'));
-        item.querySelector('.remove-item').addEventListener('click', () => item.remove());
+        container.insertBefore(item, addItemBtn);
+        item.querySelector('.remove-item').addEventListener('click', () => { item.remove(); updateAddItemBtn(); });
         const select = item.querySelector('.productTypeSelect');
         select.addEventListener('change', function(){
             const ptId = this.value;
@@ -168,7 +183,7 @@
                         const col = document.createElement('div');
                         col.className = 'col-md-6 mb-3';
                         col.innerHTML = `<label class="form-label">${mt.name} (${mt.unit})</label>`+
-                            `<input type=\"number\" step=\"0.1\" class=\"form-control measurement-input\" name=\"item${idx}_m${mt.id}\" placeholder=\"cm\" required>`;
+                            `<input type=\"number\" step=\"0.1\" class=\"form-control measurement-input\" name=\"item${idx}_m${mt.id}\" placeholder=\"${mt.unit}\" required>`;
                         fields.appendChild(col);
                     });
                     fields.classList.remove('d-none');
@@ -185,9 +200,11 @@
                 });
         });
         itemIndex++;
+        updateAddItemBtn();
     }
-    document.getElementById('addItemBtn').addEventListener('click', addItem);
-   const totalInput = document.querySelector('input[name="total"]');
+    addItemBtn.addEventListener('click', addItem);
+    addItem();
+    const totalInput = document.querySelector('input[name="total"]');
     const depositInput = document.querySelector('input[name="deposit"]');
     function updateSummary(){
         document.getElementById('summaryTotal').textContent = totalInput.value || 0;
@@ -204,7 +221,6 @@
         materialIndex++;
     }
     document.getElementById('addMaterialBtn').addEventListener('click', addMaterial);
-    addItem();
     addMaterial();
     updateSummary();
     document.getElementById('finishBtn').addEventListener('click', function(e){

--- a/TailorSoft_COCOLAND/web/jsp/producttype/createProductType.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/producttype/createProductType.jsp
@@ -7,6 +7,7 @@
     <div class="mt-4">
         <h2>Thêm loại sản phẩm may</h2>
         <form action="" method="post" id="productTypeForm" class="mt-3">
+            <input type="hidden" name="returnUrl" value="${param.returnUrl}"/>
             <div class="mb-3">
                 <label class="form-label">Tên loại sản phẩm</label>
                 <input type="text" name="name" class="form-control" required>


### PR DESCRIPTION
## Summary
- Ensure "Add customer", "Add product type" and "Add fabric" links on the order form return to the ongoing order instead of opening new tabs by using redirect URLs
- Add a dedicated "Chọn sản phẩm" button in the order wizard that lets users add product lines and switches to "Thêm sản phẩm khác" after the first item
- Automatically show a product dropdown on the order form and, once a product type is chosen, display its measurement fields with unit-aware textboxes

## Testing
- `javac -cp "lib/*:src/java" src/java/controller/order/OrderCreateController.java`
- `apt-get install -y ant` *(fails: ca-certificates-java post-installation error)*
- `ant compile`

------
https://chatgpt.com/codex/tasks/task_b_688fb377e7488322b86df29d37f1b773