### PR TITLE
Add order cancellation flow

### DIFF
--- a/TailorSoft_COCOLAND/db/cocoland_schema.sql
+++ b/TailorSoft_COCOLAND/db/cocoland_schema.sql
@@ -57,7 +57,7 @@ CREATE TABLE don_hang (
     ma_khach INT,
     ngay_dat DATE,
     ngay_giao DATE,
-    trang_thai VARCHAR(50),
+    trang_thai VARCHAR(30) CHECK (trang_thai IN ('Dang may', 'Hoan thanh', 'Don huy')),
     tong_tien DECIMAL(12,2),
     da_coc DECIMAL(12,2),
     FOREIGN KEY (ma_khach) REFERENCES khach_hang(ma_khach)

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCancelController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCancelController.java
@@ -1,0 +1,26 @@
+package controller.order;
+
+import dao.connect.DBConnect;
+import dao.order.OrderDAO;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class OrderCancelController extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        int id = Integer.parseInt(req.getParameter("id"));
+        try (Connection c = DBConnect.getConnection()) {
+            OrderDAO dao = new OrderDAO(c);
+            dao.updateStatus(id, "Don huy");
+        } catch (SQLException ex) {
+            throw new ServletException(ex);
+        }
+        resp.sendRedirect(req.getContextPath() + "/orders?msg=cancelled");
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -215,4 +215,22 @@ public class OrderDAO {
         }
         return list;
     }
+
+    public int updateStatus(int orderId, String newStatus) throws SQLException {
+        String sql = "UPDATE don_hang SET trang_thai=? WHERE ma_don=?";
+        if (conn != null) {
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setString(1, newStatus);
+                ps.setInt(2, orderId);
+                return ps.executeUpdate();
+            }
+        } else {
+            try (Connection c = DBConnect.getConnection();
+                 PreparedStatement ps = c.prepareStatement(sql)) {
+                ps.setString(1, newStatus);
+                ps.setInt(2, orderId);
+                return ps.executeUpdate();
+            }
+        }
+    }
 }

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -106,6 +106,15 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>OrderCancelController</servlet-name>
+        <servlet-class>controller.order.OrderCancelController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>OrderCancelController</servlet-name>
+        <url-pattern>/orders/cancel</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>MeasurementListController</servlet-name>
         <servlet-class>controller.measurement.MeasurementListController</servlet-class>
     </servlet>

--- a/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
@@ -32,6 +32,7 @@
                     <option value="">Tất cả trạng thái</option>
                     <option value="Dang may">Đang may</option>
                     <option value="Hoan thanh">Hoàn thành</option>
+                    <option value="Don huy">Đơn hủy</option>
                 </select>
             </div>
             <div class="col-md-2"><input id="monthFilter" type="month" class="form-control"/></div>
@@ -70,7 +71,8 @@
                     <td><fmt:formatDate value="${o.deliveryDate}" pattern="dd-MM-yyyy"/></td>
                     <td>
                         <c:choose>
-                            <c:when test="${o.status == 'Hoan thanh'}"><span class="badge text-bg-success">Hoàn thành</span></c:when>
+                            <c:when test="${o.status eq 'Don huy'}"><span class="badge text-bg-secondary">Đơn hủy</span></c:when>
+                            <c:when test="${o.status eq 'Hoan thanh'}"><span class="badge text-bg-success">Hoàn thành</span></c:when>
                             <c:otherwise><span class="badge text-bg-info">Đang may</span></c:otherwise>
                         </c:choose>
                     </td>
@@ -80,7 +82,17 @@
                     <td class="text-center">
                         <a href="<c:url value='/orders/detail?id=${o.id}'/>" class="btn btn-sm btn-outline-secondary me-1" title="Chi tiết"><i class="fa fa-eye"></i></a>
                         <a href="#" class="btn btn-sm btn-outline-primary me-1" title="Sửa"><i class="fa fa-pen"></i></a>
-                        <a href="#" class="btn btn-sm btn-outline-success" title="In"><i class="fa fa-print"></i></a>
+                        <a href="#" class="btn btn-sm btn-outline-success me-1" title="In"><i class="fa fa-print"></i></a>
+                        <c:if test="${o.status ne 'Don huy'}">
+                            <form action="${pageContext.request.contextPath}/orders/cancel"
+                                  method="post" class="d-inline"
+                                  onsubmit="return confirm('Hủy đơn hàng này?');">
+                               <input type="hidden" name="id" value="${o.id}"/>
+                               <button class="btn btn-outline-danger btn-sm" title="Hủy">
+                                   <i class="fa fa-times"></i>
+                               </button>
+                            </form>
+                        </c:if>
                     </td>
                 </tr>
             </c:forEach>


### PR DESCRIPTION
## Summary
- allow cancelling orders by updating status instead of deleting
- add cancel button and filtering support for cancelled orders
- restrict order status values in database schema

## Testing
- `ant -noinput -q compile`


------
https://chatgpt.com/codex/tasks/task_b_689022bdb95c8322bf5a77e60c002aee