### PR TITLE
Load measurements for preselected product type

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
@@ -62,11 +62,11 @@ public class OrderCreateController extends HttpServlet {
 
                 Map<String, String[]> params = request.getParameterMap();
                 params.keySet().stream()
-                        .filter(k -> k.startsWith("productTypeId_"))
+                        .filter(k -> k.startsWith("productTypeId"))
                         .forEach(k -> {
-                            String idx = k.substring("productTypeId_".length());
+                            String idx = k.substring("productTypeId".length());
                             int ptId = Integer.parseInt(request.getParameter(k));
-                            int qty = Integer.parseInt(request.getParameter("quantity_" + idx));
+                            int qty = Integer.parseInt(request.getParameter("quantity" + idx));
 
                             OrderDetail d = new OrderDetail();
                             d.setOrderId(orderId);

--- a/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
@@ -55,7 +55,7 @@
                                 <div class="row g-3">
                                     <div class="col-md-6">
                                         <label class="form-label">Loại sản phẩm</label>
-                                        <select class="form-select productTypeSelect" name="productTypeId___INDEX__" required>
+                                        <select class="form-select productTypeSelect" name="productTypeId__INDEX__" required>
                                             <option value="" selected>--Chọn loại--</option>
                                             <c:forEach var="pt" items="${productTypes}">
                                                 <option value="${pt.id}">${pt.name}</option>
@@ -68,7 +68,7 @@
                                     </div>
                                     <div class="col-md-2">
                                         <label class="form-label">Số lượng</label>
-                                        <input type="number" class="form-control" name="quantity___INDEX__" value="1" min="1" required>
+                                        <input type="number" class="form-control" name="quantity__INDEX__" value="1" min="1" required>
                                     </div>
                                 </div>
 
@@ -239,8 +239,14 @@
             }
 
             itemsContainer.insertBefore(card, addItemBtn);
-            itemIndex++;
             updateAddBtnLabel();
+
+            // Load measurements immediately if a value is preselected
+            if (select.value) {
+                loadMeasurements(select, card);
+            }
+
+            itemIndex++;
         }
 
         async function loadMeasurements(select, card){


### PR DESCRIPTION
## Summary
- Fix product template placeholders to avoid extra underscores and ensure correct field names
- Immediately load measurement inputs when a product type is already selected
- Update order creation controller to parse new product type and quantity parameter names

## Testing
- `javac -cp "$CLASSPATH" -d /tmp/build @/tmp/sources.txt`
- `ls /tmp/build/controller/order`

------
https://chatgpt.com/codex/tasks/task_b_68902c844e308322a9559fdc2c6984a6