### PR TITLE
Enable editing of order detail measurements

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/MeasurementByDetailApi.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/MeasurementByDetailApi.java
@@ -1,0 +1,29 @@
+package controller.order;
+
+import com.google.gson.Gson;
+import dao.measurement.MeasurementDAO;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class MeasurementByDetailApi extends HttpServlet {
+    private final MeasurementDAO dao = new MeasurementDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String idStr = req.getParameter("id");
+        if (idStr == null) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        int id = Integer.parseInt(idStr);
+        List<Map<String, Object>> list = dao.findByOrderDetail(id);
+        resp.setContentType("application/json;charset=UTF-8");
+        resp.getWriter().print(new Gson().toJson(list));
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
@@ -1,0 +1,45 @@
+package controller.order;
+
+import dao.connect.DBConnect;
+import dao.measurement.MeasurementDAO;
+import dao.order.OrderDAO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class OrderDetailUpdateController extends HttpServlet {
+    private final OrderDAO orderDAO = new OrderDAO();
+    private final MeasurementDAO measurementDAO = new MeasurementDAO();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.setCharacterEncoding("UTF-8");
+        int detailId = Integer.parseInt(req.getParameter("detailId"));
+        int qty = Integer.parseInt(req.getParameter("quantity"));
+
+        try (Connection c = DBConnect.getConnection()) {
+            c.setAutoCommit(false);
+            orderDAO.updateDetailQuantity(c, detailId, qty);
+            req.getParameterMap().forEach((k, v) -> {
+                if (k.startsWith("m_")) {
+                    int mId = Integer.parseInt(k.substring(2));
+                    double val = Double.parseDouble(v[0]);
+                    try {
+                        measurementDAO.updateValueById(c, mId, val);
+                    } catch (SQLException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            });
+            c.commit();
+            resp.setStatus(HttpServletResponse.SC_OK);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
@@ -6,6 +6,8 @@ import model.Measurement;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MeasurementDAO {
     private final Connection conn;
@@ -69,6 +71,39 @@ public class MeasurementDAO {
                 ps.setString(5, measurement.getNote());
                 ps.executeUpdate();
             }
+        }
+    }
+
+    public List<Map<String, Object>> findByOrderDetail(int detailId) {
+        List<Map<String, Object>> list = new ArrayList<>();
+        String sql = "SELECT tsd.ma_do, lt.ten_thong_so, lt.don_vi, tsd.gia_tri " +
+                "FROM thong_so_do tsd JOIN loai_thong_so lt ON tsd.ma_thong_so = lt.ma_thong_so " +
+                "WHERE tsd.ma_ct = ?";
+        try (Connection c = DBConnect.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, detailId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("id", rs.getInt("ma_do"));
+                    m.put("name", rs.getString("ten_thong_so"));
+                    m.put("unit", rs.getString("don_vi"));
+                    m.put("value", rs.getDouble("gia_tri"));
+                    list.add(m);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public void updateValueById(Connection c, int id, double value) throws SQLException {
+        String sql = "UPDATE thong_so_do SET gia_tri=? WHERE ma_do=?";
+        try (PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setDouble(1, value);
+            ps.setInt(2, id);
+            ps.executeUpdate();
         }
     }
 }

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -216,6 +216,15 @@ public class OrderDAO {
         return list;
     }
 
+    public void updateDetailQuantity(Connection c, int detailId, int qty) throws SQLException {
+        String sql = "UPDATE chi_tiet_don SET so_luong=? WHERE ma_ct=?";
+        try (PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, qty);
+            ps.setInt(2, detailId);
+            ps.executeUpdate();
+        }
+    }
+
     public int updateStatus(int orderId, String newStatus) throws SQLException {
         String sql = "UPDATE don_hang SET trang_thai=? WHERE ma_don=?";
         if (conn != null) {

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -204,4 +204,22 @@
         <url-pattern>/customers/update</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>MeasurementByDetailApi</servlet-name>
+        <servlet-class>controller.order.MeasurementByDetailApi</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MeasurementByDetailApi</servlet-name>
+        <url-pattern>/order-details/measurements</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>OrderDetailUpdateController</servlet-name>
+        <servlet-class>controller.order.OrderDetailUpdateController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>OrderDetailUpdateController</servlet-name>
+        <url-pattern>/order-details/update</url-pattern>
+    </servlet-mapping>
+
 </web-app>

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -34,6 +34,7 @@
                         <th>Đơn giá</th>
                         <th>Số lượng</th>
                         <th>Ghi chú</th>
+                        <th></th>
                     </tr>
                     </thead>
                     <tbody>
@@ -44,6 +45,7 @@
                             <td><fmt:formatNumber value="${d.unitPrice}" type="number" groupingUsed="true"/> ₫</td>
                             <td>${d.quantity}</td>
                             <td>${d.note}</td>
+                            <td><button type="button" class="btn btn-sm btn-outline-primary edit-detail" data-id="${d.id}" data-qty="${d.quantity}"><i class="fa fa-pen"></i></button></td>
                         </tr>
                     </c:forEach>
                     </tbody>
@@ -58,4 +60,61 @@
         <a href="<c:url value='/orders'/>">Quay lại</a>
     </div>
 </div>
+
+<div class="modal fade" id="editDetailModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <form id="editDetailForm" class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Cập nhật chi tiết</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" name="detailId" id="detailId">
+                <div class="mb-3">
+                    <label class="form-label">Số lượng</label>
+                    <input type="number" min="1" class="form-control" name="quantity" id="quantity">
+                </div>
+                <div id="measurementList"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+                <button type="submit" class="btn btn-primary">Lưu</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    $(function () {
+        const baseUrl = '${pageContext.request.contextPath}';
+        const modal = new bootstrap.Modal(document.getElementById('editDetailModal'));
+
+        $('.edit-detail').on('click', function () {
+            const id = $(this).data('id');
+            const qty = $(this).data('qty');
+            $('#detailId').val(id);
+            $('#quantity').val(qty);
+            $('#measurementList').empty();
+            $.getJSON(baseUrl + '/order-details/measurements', {id: id}, function (list) {
+                list.forEach(function (m) {
+                    const item = `<div class="mb-3">
+                            <label class="form-label">${m.name} (${m.unit})</label>
+                            <input type="number" step="0.01" class="form-control" name="m_${m.id}" value="${m.value}">
+                        </div>`;
+                    $('#measurementList').append(item);
+                });
+                modal.show();
+            });
+        });
+
+        $('#editDetailForm').on('submit', function (e) {
+            e.preventDefault();
+            $.post(baseUrl + '/order-details/update', $(this).serialize())
+                .done(function () {
+                    location.reload();
+                });
+        });
+    });
+</script>
+
 <jsp:include page="/jsp/common/footer.jsp"/>


### PR DESCRIPTION
## Summary
- add edit button and modal to order detail page for quantity and measurement updates
- introduce API servlets for loading measurements and saving edits
- update DAO methods and servlet mappings to persist edits

## Testing
- `ant compile`


------
https://chatgpt.com/codex/tasks/task_b_68903035dae8832297de843d6d134cfc