### PR TITLE
Add note editing and product detail view

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
@@ -20,10 +20,11 @@ public class OrderDetailUpdateController extends HttpServlet {
         req.setCharacterEncoding("UTF-8");
         int detailId = Integer.parseInt(req.getParameter("detailId"));
         int qty = Integer.parseInt(req.getParameter("quantity"));
+        String note = req.getParameter("note");
 
         try (Connection c = DBConnect.getConnection()) {
             c.setAutoCommit(false);
-            orderDAO.updateDetailQuantity(c, detailId, qty);
+            orderDAO.updateDetail(c, detailId, qty, note);
             req.getParameterMap().forEach((k, v) -> {
                 if (k.startsWith("m_")) {
                     int mId = Integer.parseInt(k.substring(2));

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -216,11 +216,28 @@ public class OrderDAO {
         return list;
     }
 
-    public void updateDetailQuantity(Connection c, int detailId, int qty) throws SQLException {
-        String sql = "UPDATE chi_tiet_don SET so_luong=? WHERE ma_ct=?";
-        try (PreparedStatement ps = c.prepareStatement(sql)) {
+    public void updateDetail(Connection c, int detailId, int qty, String note) throws SQLException {
+        int orderId = 0;
+        String getSql = "SELECT ma_don FROM chi_tiet_don WHERE ma_ct=?";
+        try (PreparedStatement ps = c.prepareStatement(getSql)) {
+            ps.setInt(1, detailId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    orderId = rs.getInt(1);
+                }
+            }
+        }
+        String updateSql = "UPDATE chi_tiet_don SET so_luong=?, ghi_chu=? WHERE ma_ct=?";
+        try (PreparedStatement ps = c.prepareStatement(updateSql)) {
             ps.setInt(1, qty);
-            ps.setInt(2, detailId);
+            ps.setString(2, note);
+            ps.setInt(3, detailId);
+            ps.executeUpdate();
+        }
+        String totalSql = "UPDATE don_hang SET tong_tien = (SELECT SUM(so_luong*don_gia) FROM chi_tiet_don WHERE ma_don=?) WHERE ma_don=?";
+        try (PreparedStatement ps = c.prepareStatement(totalSql)) {
+            ps.setInt(1, orderId);
+            ps.setInt(2, orderId);
             ps.executeUpdate();
         }
     }

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -45,7 +45,12 @@
                             <td><fmt:formatNumber value="${d.unitPrice}" type="number" groupingUsed="true"/> ₫</td>
                             <td>${d.quantity}</td>
                             <td>${d.note}</td>
-                            <td><button type="button" class="btn btn-sm btn-outline-primary edit-detail" data-id="${d.id}" data-qty="${d.quantity}"><i class="fa fa-pen"></i></button></td>
+                            <td>
+                                <div class="btn-group btn-group-sm">
+                                    <button type="button" class="btn btn-outline-secondary view-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}"><i class="fa fa-eye"></i></button>
+                                    <button type="button" class="btn btn-outline-primary edit-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}"><i class="fa fa-pen"></i></button>
+                                </div>
+                            </td>
                         </tr>
                     </c:forEach>
                     </tbody>
@@ -74,11 +79,15 @@
                     <label class="form-label">Số lượng</label>
                     <input type="number" min="1" class="form-control" name="quantity" id="quantity">
                 </div>
+                <div class="mb-3">
+                    <label class="form-label">Ghi chú</label>
+                    <textarea class="form-control" name="note" id="note" rows="2"></textarea>
+                </div>
                 <div id="measurementList"></div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
-                <button type="submit" class="btn btn-primary">Lưu</button>
+                <button type="submit" class="btn btn-primary" id="saveBtn">Lưu</button>
             </div>
         </form>
     </div>
@@ -87,24 +96,43 @@
 <script>
     $(function () {
         const baseUrl = '${pageContext.request.contextPath}';
-        const modal = new bootstrap.Modal(document.getElementById('editDetailModal'));
+        const modalEl = document.getElementById('editDetailModal');
+        const modal = new bootstrap.Modal(modalEl);
 
-        $('.edit-detail').on('click', function () {
-            const id = $(this).data('id');
-            const qty = $(this).data('qty');
-            $('#detailId').val(id);
-            $('#quantity').val(qty);
+        function loadMeasurements(id, disabled) {
             $('#measurementList').empty();
             $.getJSON(baseUrl + '/order-details/measurements', {id: id}, function (list) {
                 list.forEach(function (m) {
                     const item = `<div class="mb-3">
                             <label class="form-label">${m.name} (${m.unit})</label>
-                            <input type="number" step="0.01" class="form-control" name="m_${m.id}" value="${m.value}">
+                            <input type="number" step="0.01" class="form-control" name="m_${m.id}" value="${m.value}" ${disabled ? 'disabled' : ''}>
                         </div>`;
                     $('#measurementList').append(item);
                 });
                 modal.show();
             });
+        }
+
+        $('.view-detail').on('click', function () {
+            const id = $(this).data('id');
+            const qty = $(this).data('qty');
+            const note = $(this).data('note');
+            $('#detailId').val(id);
+            $('#quantity').val(qty).prop('disabled', true);
+            $('#note').val(note).prop('disabled', true);
+            $('#saveBtn').hide();
+            loadMeasurements(id, true);
+        });
+
+        $('.edit-detail').on('click', function () {
+            const id = $(this).data('id');
+            const qty = $(this).data('qty');
+            const note = $(this).data('note');
+            $('#detailId').val(id);
+            $('#quantity').val(qty).prop('disabled', false);
+            $('#note').val(note).prop('disabled', false);
+            $('#saveBtn').show();
+            loadMeasurements(id, false);
         });
 
         $('#editDetailForm').on('submit', function (e) {


### PR DESCRIPTION
## Summary
- Allow viewing a product's measurements and note via a new view button on order detail rows.
- Support editing the product note alongside measurements and quantity in the modal dialog.
- Persist updated quantity and note while recalculating order totals on the backend.

## Testing
- `ant -noinput -q compile`


------
https://chatgpt.com/codex/tasks/task_b_689037ddd3d08322884db59c339a375c