### PR TITLE
feat: allow editing order notes and amounts

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
@@ -67,6 +67,7 @@ public class OrderCreateController extends HttpServlet {
                             String idx = k.substring("productTypeId".length());
                             int ptId = Integer.parseInt(request.getParameter(k));
                             int qty = Integer.parseInt(request.getParameter("quantity" + idx));
+                            String note = request.getParameter("note" + idx);
 
                             OrderDetail d = new OrderDetail();
                             d.setOrderId(orderId);
@@ -74,6 +75,7 @@ public class OrderCreateController extends HttpServlet {
                             d.setMaterialName("");
                             d.setUnitPrice(0);
                             d.setQuantity(qty);
+                            d.setNote(note);
                             try {
                                 orderDAO.insertDetail(d);
                             } catch (SQLException e) {

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailUpdateController.java
@@ -21,10 +21,11 @@ public class OrderDetailUpdateController extends HttpServlet {
         int detailId = Integer.parseInt(req.getParameter("detailId"));
         int qty = Integer.parseInt(req.getParameter("quantity"));
         String note = req.getParameter("note");
+        double price = Double.parseDouble(req.getParameter("unitPrice"));
 
         try (Connection c = DBConnect.getConnection()) {
             c.setAutoCommit(false);
-            orderDAO.updateDetail(c, detailId, qty, note);
+            orderDAO.updateDetail(c, detailId, qty, note, price);
             req.getParameterMap().forEach((k, v) -> {
                 if (k.startsWith("m_")) {
                     int mId = Integer.parseInt(k.substring(2));

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderUpdateAmountController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderUpdateAmountController.java
@@ -1,0 +1,32 @@
+package controller.order;
+
+import dao.order.OrderDAO;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class OrderUpdateAmountController extends HttpServlet {
+    private final OrderDAO orderDAO = new OrderDAO();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        int orderId = Integer.parseInt(req.getParameter("orderId"));
+        double total = Double.parseDouble(req.getParameter("total"));
+        double deposit = Double.parseDouble(req.getParameter("deposit"));
+        if (deposit > total) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        try {
+            orderDAO.updateAmounts(orderId, total, deposit);
+            resp.setStatus(HttpServletResponse.SC_OK);
+        } catch (SQLException ex) {
+            throw new ServletException(ex);
+        }
+    }
+}
+

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -216,7 +216,7 @@ public class OrderDAO {
         return list;
     }
 
-    public void updateDetail(Connection c, int detailId, int qty, String note) throws SQLException {
+    public void updateDetail(Connection c, int detailId, int qty, String note, double unitPrice) throws SQLException {
         int orderId = 0;
         String getSql = "SELECT ma_don FROM chi_tiet_don WHERE ma_ct=?";
         try (PreparedStatement ps = c.prepareStatement(getSql)) {
@@ -227,11 +227,12 @@ public class OrderDAO {
                 }
             }
         }
-        String updateSql = "UPDATE chi_tiet_don SET so_luong=?, ghi_chu=? WHERE ma_ct=?";
+        String updateSql = "UPDATE chi_tiet_don SET so_luong=?, ghi_chu=?, don_gia=? WHERE ma_ct=?";
         try (PreparedStatement ps = c.prepareStatement(updateSql)) {
             ps.setInt(1, qty);
             ps.setString(2, note);
-            ps.setInt(3, detailId);
+            ps.setDouble(3, unitPrice);
+            ps.setInt(4, detailId);
             ps.executeUpdate();
         }
         String totalSql = "UPDATE don_hang SET tong_tien = (SELECT SUM(so_luong*don_gia) FROM chi_tiet_don WHERE ma_don=?) WHERE ma_don=?";
@@ -256,6 +257,26 @@ public class OrderDAO {
                 ps.setString(1, newStatus);
                 ps.setInt(2, orderId);
                 return ps.executeUpdate();
+            }
+        }
+    }
+
+    public void updateAmounts(int orderId, double total, double deposit) throws SQLException {
+        String sql = "UPDATE don_hang SET tong_tien=?, da_coc=? WHERE ma_don=?";
+        if (conn != null) {
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setDouble(1, total);
+                ps.setDouble(2, deposit);
+                ps.setInt(3, orderId);
+                ps.executeUpdate();
+            }
+        } else {
+            try (Connection c = DBConnect.getConnection();
+                 PreparedStatement ps = c.prepareStatement(sql)) {
+                ps.setDouble(1, total);
+                ps.setDouble(2, deposit);
+                ps.setInt(3, orderId);
+                ps.executeUpdate();
             }
         }
     }

--- a/TailorSoft_COCOLAND/web/WEB-INF/web.xml
+++ b/TailorSoft_COCOLAND/web/WEB-INF/web.xml
@@ -222,4 +222,13 @@
         <url-pattern>/order-details/update</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>OrderUpdateAmountController</servlet-name>
+        <servlet-class>controller.order.OrderUpdateAmountController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>OrderUpdateAmountController</servlet-name>
+        <url-pattern>/orders/update-amount</url-pattern>
+    </servlet-mapping>
+
 </web-app>

--- a/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
@@ -70,6 +70,10 @@
                                         <label class="form-label">Số lượng</label>
                                         <input type="number" class="form-control" name="quantity__INDEX__" value="1" min="1" required>
                                     </div>
+                                    <div class="col-md-4">
+                                        <label class="form-label">Ghi chú</label>
+                                        <textarea class="form-control" name="note__INDEX__" rows="1"></textarea>
+                                    </div>
                                 </div>
 
                                 <div class="measurement-wrapper mt-4 d-none">

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -21,6 +21,7 @@
                             <p><strong>Tổng tiền:</strong> <fmt:formatNumber value="${order.total}" type="number" groupingUsed="true"/> ₫</p>
                             <p><strong>Đã cọc:</strong> <fmt:formatNumber value="${order.deposit}" type="number" groupingUsed="true"/> ₫</p>
                             <p><strong>Còn lại:</strong> <fmt:formatNumber value="${order.total - order.deposit}" type="number" groupingUsed="true"/> ₫</p>
+                            <button type="button" class="btn btn-outline-primary btn-sm" id="editOrderBtn" data-id="${order.id}" data-total="${order.total}" data-deposit="${order.deposit}"><i class="fa fa-pen"></i> Sửa tiền</button>
                         </div>
                     </div>
                 </div>
@@ -47,8 +48,8 @@
                             <td>${d.note}</td>
                             <td>
                                 <div class="btn-group btn-group-sm">
-                                    <button type="button" class="btn btn-outline-secondary view-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}"><i class="fa fa-eye"></i></button>
-                                    <button type="button" class="btn btn-outline-primary edit-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}"><i class="fa fa-pen"></i></button>
+                                    <button type="button" class="btn btn-outline-secondary view-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}" data-price="${d.unitPrice}"><i class="fa fa-eye"></i></button>
+                                    <button type="button" class="btn btn-outline-primary edit-detail" data-id="${d.id}" data-qty="${d.quantity}" data-note="${d.note}" data-price="${d.unitPrice}"><i class="fa fa-pen"></i></button>
                                 </div>
                             </td>
                         </tr>
@@ -75,19 +76,49 @@
             </div>
             <div class="modal-body">
                 <input type="hidden" name="detailId" id="detailId">
-                <div class="mb-3">
-                    <label class="form-label">Số lượng</label>
-                    <input type="number" min="1" class="form-control" name="quantity" id="quantity">
-                </div>
-                <div class="mb-3">
-                    <label class="form-label">Ghi chú</label>
-                    <textarea class="form-control" name="note" id="note" rows="2"></textarea>
-                </div>
+                        <div class="mb-3">
+                            <label class="form-label">Số lượng</label>
+                            <input type="number" min="1" class="form-control" name="quantity" id="quantity">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Đơn giá</label>
+                            <input type="number" step="1000" class="form-control" name="unitPrice" id="unitPrice">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Ghi chú</label>
+                            <textarea class="form-control" name="note" id="note" rows="2"></textarea>
+                        </div>
                 <div id="measurementList"></div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
                 <button type="submit" class="btn btn-primary" id="saveBtn">Lưu</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="modal fade" id="editOrderModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <form id="editOrderForm" class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Cập nhật tiền đơn hàng</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" name="orderId" id="orderId">
+                <div class="mb-3">
+                    <label class="form-label">Tổng tiền</label>
+                    <input type="number" step="1000" class="form-control" name="total" id="orderTotal">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Đã cọc</label>
+                    <input type="number" step="1000" class="form-control" name="deposit" id="orderDeposit">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+                <button type="submit" class="btn btn-primary">Lưu</button>
             </div>
         </form>
     </div>
@@ -117,9 +148,11 @@
             const id = $(this).data('id');
             const qty = $(this).data('qty');
             const note = $(this).data('note');
+            const price = $(this).data('price');
             $('#detailId').val(id);
             $('#quantity').val(qty).prop('disabled', true);
             $('#note').val(note).prop('disabled', true);
+            $('#unitPrice').val(price).prop('disabled', true);
             $('#saveBtn').hide();
             loadMeasurements(id, true);
         });
@@ -128,9 +161,11 @@
             const id = $(this).data('id');
             const qty = $(this).data('qty');
             const note = $(this).data('note');
+            const price = $(this).data('price');
             $('#detailId').val(id);
             $('#quantity').val(qty).prop('disabled', false);
             $('#note').val(note).prop('disabled', false);
+            $('#unitPrice').val(price).prop('disabled', false);
             $('#saveBtn').show();
             loadMeasurements(id, false);
         });
@@ -141,6 +176,20 @@
                 .done(function () {
                     location.reload();
                 });
+        });
+
+        const orderModal = new bootstrap.Modal(document.getElementById('editOrderModal'));
+        $('#editOrderBtn').on('click', function(){
+            $('#orderId').val($(this).data('id'));
+            $('#orderTotal').val($(this).data('total'));
+            $('#orderDeposit').val($(this).data('deposit'));
+            orderModal.show();
+        });
+
+        $('#editOrderForm').on('submit', function(e){
+            e.preventDefault();
+            $.post(baseUrl + '/orders/update-amount', $(this).serialize())
+                .done(function(){ location.reload(); });
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- add product note field when creating orders
- enable editing unit prices, notes and measurements in order details
- support updating order total and deposit values

## Testing
- `ant -q compile`


------
https://chatgpt.com/codex/tasks/task_b_68903aeaa07083228c028e71f8ffa330