### PR TITLE
Link measurements to order details

### DIFF
--- a/TailorSoft_COCOLAND/db/cocoland_schema.sql
+++ b/TailorSoft_COCOLAND/db/cocoland_schema.sql
@@ -44,11 +44,13 @@ CREATE TABLE thong_so_do (
     ma_khach INT,
     ma_loai INT,
     ma_thong_so INT,
+    ma_ct INT,
     gia_tri FLOAT,
     ghi_chu TEXT,
     FOREIGN KEY (ma_khach) REFERENCES khach_hang(ma_khach),
     FOREIGN KEY (ma_loai) REFERENCES loai_san_pham(ma_loai),
-    FOREIGN KEY (ma_thong_so) REFERENCES loai_thong_so(ma_thong_so)
+    FOREIGN KEY (ma_thong_so) REFERENCES loai_thong_so(ma_thong_so),
+    FOREIGN KEY (ma_ct) REFERENCES chi_tiet_don(ma_ct)
 );
 
 -- ĐƠN HÀNG
@@ -130,7 +132,7 @@ INSERT INTO chi_tiet_don (ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu) 
 (1, 'Vest nam', 'Kate silk', 1250000, 1, 'May theo form slim fit');
 
 -- 8. Thông số đo thực tế của khách
-INSERT INTO thong_so_do (ma_khach, ma_loai, ma_thong_so, gia_tri) VALUES
-(1, 1, 1, 38.5),
-(1, 1, 2, 60.0),
-(1, 1, 3, 44.0);
+INSERT INTO thong_so_do (ma_khach, ma_loai, ma_thong_so, gia_tri, ma_ct) VALUES
+(1, 1, 1, 38.5, 1),
+(1, 1, 2, 60.0, 1),
+(1, 1, 3, 44.0, 1);

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
@@ -76,8 +76,9 @@ public class OrderCreateController extends HttpServlet {
                             d.setUnitPrice(0);
                             d.setQuantity(qty);
                             d.setNote(note);
+                            int detailId;
                             try {
-                                orderDAO.insertDetail(d);
+                                detailId = orderDAO.insertDetail(d);
                             } catch (SQLException e) {
                                 throw new RuntimeException(e);
                             }
@@ -93,6 +94,7 @@ public class OrderCreateController extends HttpServlet {
                                         m.setProductTypeId(ptId);
                                         m.setMeasurementTypeId(mtId);
                                         m.setValue(val);
+                                        m.setOrderDetailId(detailId);
                                         try {
                                             measurementDAO.insert(m);
                                         } catch (SQLException e) {

--- a/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
@@ -23,7 +23,7 @@ public class MeasurementDAO {
     public List<Measurement> findAll() {
         List<Measurement> list = new ArrayList<>();
         String sql = "SELECT tsd.ma_do, tsd.ma_khach, k.ho_ten, tsd.ma_loai, l.ten_loai, " +
-                "tsd.ma_thong_so, t.ten_thong_so, tsd.gia_tri, tsd.ghi_chu " +
+                "tsd.ma_thong_so, t.ten_thong_so, tsd.gia_tri, tsd.ghi_chu, tsd.ma_ct " +
                 "FROM thong_so_do tsd " +
                 "JOIN khach_hang k ON tsd.ma_khach = k.ma_khach " +
                 "JOIN loai_san_pham l ON tsd.ma_loai = l.ma_loai " +
@@ -42,6 +42,7 @@ public class MeasurementDAO {
                 m.setMeasurementTypeName(rs.getString("ten_thong_so"));
                 m.setValue(rs.getDouble("gia_tri"));
                 m.setNote(rs.getString("ghi_chu"));
+                m.setOrderDetailId(rs.getInt("ma_ct"));
                 list.add(m);
             }
         } catch (SQLException e) {
@@ -51,7 +52,7 @@ public class MeasurementDAO {
     }
 
     public void insert(Measurement measurement) throws SQLException {
-        String sql = "INSERT INTO thong_so_do(ma_khach, ma_loai, ma_thong_so, gia_tri, ghi_chu) VALUES(?,?,?,?,?)";
+        String sql = "INSERT INTO thong_so_do(ma_khach, ma_loai, ma_thong_so, gia_tri, ghi_chu, ma_ct) VALUES(?,?,?,?,?,?)";
         if (conn != null) {
             try (PreparedStatement ps = conn.prepareStatement(sql)) {
                 ps.setInt(1, measurement.getCustomerId());
@@ -59,6 +60,11 @@ public class MeasurementDAO {
                 ps.setInt(3, measurement.getMeasurementTypeId());
                 ps.setDouble(4, measurement.getValue());
                 ps.setString(5, measurement.getNote());
+                if (measurement.getOrderDetailId() > 0) {
+                    ps.setInt(6, measurement.getOrderDetailId());
+                } else {
+                    ps.setNull(6, Types.INTEGER);
+                }
                 ps.executeUpdate();
             }
         } else {
@@ -69,6 +75,11 @@ public class MeasurementDAO {
                 ps.setInt(3, measurement.getMeasurementTypeId());
                 ps.setDouble(4, measurement.getValue());
                 ps.setString(5, measurement.getNote());
+                if (measurement.getOrderDetailId() > 0) {
+                    ps.setInt(6, measurement.getOrderDetailId());
+                } else {
+                    ps.setNull(6, Types.INTEGER);
+                }
                 ps.executeUpdate();
             }
         }

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -111,10 +111,10 @@ public class OrderDAO {
         }
     }
 
-    public void insertDetail(OrderDetail detail) throws SQLException {
+    public int insertDetail(OrderDetail detail) throws SQLException {
         String sql = "INSERT INTO chi_tiet_don(ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu) VALUES(?,?,?,?,?,?)";
         if (conn != null) {
-            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
                 ps.setString(3, detail.getMaterialName());
@@ -122,10 +122,16 @@ public class OrderDAO {
                 ps.setInt(5, detail.getQuantity());
                 ps.setString(6, detail.getNote());
                 ps.executeUpdate();
+                try (ResultSet rs = ps.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        return rs.getInt(1);
+                    }
+                }
             }
+            return -1;
         } else {
             try (Connection c = DBConnect.getConnection();
-                 PreparedStatement ps = c.prepareStatement(sql)) {
+                 PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
                 ps.setString(3, detail.getMaterialName());
@@ -133,7 +139,13 @@ public class OrderDAO {
                 ps.setInt(5, detail.getQuantity());
                 ps.setString(6, detail.getNote());
                 ps.executeUpdate();
+                try (ResultSet rs = ps.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        return rs.getInt(1);
+                    }
+                }
             }
+            return -1;
         }
     }
 

--- a/TailorSoft_COCOLAND/src/java/model/Measurement.java
+++ b/TailorSoft_COCOLAND/src/java/model/Measurement.java
@@ -10,12 +10,13 @@ public class Measurement {
     private String measurementTypeName;
     private double value;
     private String note;
+    private int orderDetailId;
 
     public Measurement() {}
 
     public Measurement(int id, int customerId, String customerName, int productTypeId,
                        String productTypeName, int measurementTypeId, String measurementTypeName,
-                       double value, String note) {
+                       double value, String note, int orderDetailId) {
         this.id = id;
         this.customerId = customerId;
         this.customerName = customerName;
@@ -25,6 +26,7 @@ public class Measurement {
         this.measurementTypeName = measurementTypeName;
         this.value = value;
         this.note = note;
+        this.orderDetailId = orderDetailId;
     }
 
     public int getId() { return id; }
@@ -45,4 +47,6 @@ public class Measurement {
     public void setValue(double value) { this.value = value; }
     public String getNote() { return note; }
     public void setNote(String note) { this.note = note; }
+    public int getOrderDetailId() { return orderDetailId; }
+    public void setOrderDetailId(int orderDetailId) { this.orderDetailId = orderDetailId; }
 }


### PR DESCRIPTION
## Summary
- Track measurement entries by order detail to show/edit measurements per product
- Persist order detail IDs when creating orders
- Update schema for `thong_so_do` to reference order detail rows

## Testing
- `ant compile`
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_68904068e31483229411f8beb04fe771