### PR TITLE
Link materials with order details and persist measurements

### DIFF
--- a/TailorSoft_COCOLAND/db/cocoland_schema.sql
+++ b/TailorSoft_COCOLAND/db/cocoland_schema.sql
@@ -71,11 +71,13 @@ CREATE TABLE chi_tiet_don (
     ma_ct INT PRIMARY KEY AUTO_INCREMENT,
     ma_don INT,
     loai_sp VARCHAR(50),
+    ma_vai INT,
     ten_vai VARCHAR(100),
     don_gia DECIMAL(10,2),
     so_luong INT,
     ghi_chu TEXT,
-    FOREIGN KEY (ma_don) REFERENCES don_hang(ma_don)
+    FOREIGN KEY (ma_don) REFERENCES don_hang(ma_don),
+    FOREIGN KEY (ma_vai) REFERENCES kho_vai(ma_vai)
 );
 
 -- SỐ ĐO
@@ -144,8 +146,8 @@ INSERT INTO don_hang (ma_khach, ngay_dat, ngay_giao, trang_thai, tong_tien, da_c
 (1, '2025-08-01', '2025-08-10', 'Dang may', 2500000, 1000000);
 
 -- 7. Chi tiết đơn hàng
-INSERT INTO chi_tiet_don (ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu) VALUES
-(1, 'Vest nam', 'Kate silk', 1250000, 1, 'May theo form slim fit');
+INSERT INTO chi_tiet_don (ma_don, loai_sp, ma_vai, ten_vai, don_gia, so_luong, ghi_chu) VALUES
+(1, 'Vest nam', 1, 'Kate silk', 1250000, 1, 'May theo form slim fit');
 
 -- 8. Thông số đo thực tế của khách
 INSERT INTO thong_so_do (ma_khach, ma_loai, ma_thong_so, gia_tri, ma_ct) VALUES

--- a/TailorSoft_COCOLAND/src/java/dao/material/MaterialDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/material/MaterialDAO.java
@@ -57,6 +57,30 @@ public class MaterialDAO {
         }
     }
 
+    public Material findById(int id) {
+        String sql = "SELECT ma_vai, ten_vai, mau_sac, xuat_xu, gia_thanh, so_luong, hinh_hoa_don FROM kho_vai WHERE ma_vai=?";
+        try (Connection c = conn != null ? conn : DBConnect.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Material m = new Material();
+                    m.setId(rs.getInt("ma_vai"));
+                    m.setName(rs.getString("ten_vai"));
+                    m.setColor(rs.getString("mau_sac"));
+                    m.setOrigin(rs.getString("xuat_xu"));
+                    m.setPrice(rs.getDouble("gia_thanh"));
+                    m.setQuantity(rs.getDouble("so_luong"));
+                    m.setInvoiceImage(rs.getString("hinh_hoa_don"));
+                    return m;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     public void decreaseQuantity(int id, double amount) throws SQLException {
         String sql = "UPDATE kho_vai SET so_luong = so_luong - ? WHERE ma_vai = ?";
         if (conn != null) {

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -112,15 +112,16 @@ public class OrderDAO {
     }
 
     public int insertDetail(OrderDetail detail) throws SQLException {
-        String sql = "INSERT INTO chi_tiet_don(ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu) VALUES(?,?,?,?,?,?)";
+        String sql = "INSERT INTO chi_tiet_don(ma_don, loai_sp, ma_vai, ten_vai, don_gia, so_luong, ghi_chu) VALUES(?,?,?,?,?,?,?)";
         if (conn != null) {
             try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setString(3, detail.getMaterialName());
-                ps.setDouble(4, detail.getUnitPrice());
-                ps.setInt(5, detail.getQuantity());
-                ps.setString(6, detail.getNote());
+                ps.setInt(3, detail.getMaterialId());
+                ps.setString(4, detail.getMaterialName());
+                ps.setDouble(5, detail.getUnitPrice());
+                ps.setInt(6, detail.getQuantity());
+                ps.setString(7, detail.getNote());
                 ps.executeUpdate();
                 try (ResultSet rs = ps.getGeneratedKeys()) {
                     if (rs.next()) {
@@ -134,10 +135,11 @@ public class OrderDAO {
                  PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setString(3, detail.getMaterialName());
-                ps.setDouble(4, detail.getUnitPrice());
-                ps.setInt(5, detail.getQuantity());
-                ps.setString(6, detail.getNote());
+                ps.setInt(3, detail.getMaterialId());
+                ps.setString(4, detail.getMaterialName());
+                ps.setDouble(5, detail.getUnitPrice());
+                ps.setInt(6, detail.getQuantity());
+                ps.setString(7, detail.getNote());
                 ps.executeUpdate();
                 try (ResultSet rs = ps.getGeneratedKeys()) {
                     if (rs.next()) {
@@ -151,7 +153,7 @@ public class OrderDAO {
 
     public List<OrderDetail> findDetailsByOrder(int orderId) {
         List<OrderDetail> list = new ArrayList<>();
-        String sql = "SELECT ma_ct, ma_don, loai_sp, ten_vai, don_gia, so_luong, ghi_chu FROM chi_tiet_don WHERE ma_don = ?";
+        String sql = "SELECT ma_ct, ma_don, loai_sp, ma_vai, ten_vai, don_gia, so_luong, ghi_chu FROM chi_tiet_don WHERE ma_don = ?";
         try (Connection conn = DBConnect.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, orderId);
@@ -161,6 +163,7 @@ public class OrderDAO {
                     d.setId(rs.getInt("ma_ct"));
                     d.setOrderId(rs.getInt("ma_don"));
                     d.setProductType(rs.getString("loai_sp"));
+                    d.setMaterialId(rs.getInt("ma_vai"));
                     d.setMaterialName(rs.getString("ten_vai"));
                     d.setUnitPrice(rs.getDouble("don_gia"));
                     d.setQuantity(rs.getInt("so_luong"));
@@ -176,7 +179,7 @@ public class OrderDAO {
 
     public List<OrderDetail> findDetailsByCustomer(int customerId) {
         List<OrderDetail> list = new ArrayList<>();
-        String sql = "SELECT ct.ma_ct, ct.ma_don, ct.loai_sp, ct.ten_vai, ct.don_gia, ct.so_luong, ct.ghi_chu " +
+        String sql = "SELECT ct.ma_ct, ct.ma_don, ct.loai_sp, ct.ma_vai, ct.ten_vai, ct.don_gia, ct.so_luong, ct.ghi_chu " +
                      "FROM chi_tiet_don ct JOIN don_hang dh ON ct.ma_don = dh.ma_don WHERE dh.ma_khach = ?";
         try (Connection conn = DBConnect.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -187,6 +190,7 @@ public class OrderDAO {
                     d.setId(rs.getInt("ma_ct"));
                     d.setOrderId(rs.getInt("ma_don"));
                     d.setProductType(rs.getString("loai_sp"));
+                    d.setMaterialId(rs.getInt("ma_vai"));
                     d.setMaterialName(rs.getString("ten_vai"));
                     d.setUnitPrice(rs.getDouble("don_gia"));
                     d.setQuantity(rs.getInt("so_luong"));

--- a/TailorSoft_COCOLAND/src/java/model/OrderDetail.java
+++ b/TailorSoft_COCOLAND/src/java/model/OrderDetail.java
@@ -4,6 +4,7 @@ public class OrderDetail {
     private int id;
     private int orderId;
     private String productType;
+    private int materialId;
     private String materialName;
     private double unitPrice;
     private int quantity;
@@ -11,10 +12,11 @@ public class OrderDetail {
 
     public OrderDetail() {}
 
-    public OrderDetail(int id, int orderId, String productType, String materialName, double unitPrice, int quantity, String note) {
+    public OrderDetail(int id, int orderId, String productType, int materialId, String materialName, double unitPrice, int quantity, String note) {
         this.id = id;
         this.orderId = orderId;
         this.productType = productType;
+        this.materialId = materialId;
         this.materialName = materialName;
         this.unitPrice = unitPrice;
         this.quantity = quantity;
@@ -27,6 +29,8 @@ public class OrderDetail {
     public void setOrderId(int orderId) { this.orderId = orderId; }
     public String getProductType() { return productType; }
     public void setProductType(String productType) { this.productType = productType; }
+    public int getMaterialId() { return materialId; }
+    public void setMaterialId(int materialId) { this.materialId = materialId; }
     public String getMaterialName() { return materialName; }
     public void setMaterialName(String materialName) { this.materialName = materialName; }
     public double getUnitPrice() { return unitPrice; }


### PR DESCRIPTION
## Summary
- Track fabric usage by linking order details to materials and reducing inventory
- Persist measurements for each order item during order creation

## Testing
- `ant compile` *(fails: ant missing and ca-certificates-java configuration error)*

------
https://chatgpt.com/codex/tasks/task_b_6890554eab648322bf2a8c7b5e429e51