### PR TITLE
Rename deposit to paid and mark fully paid orders

### DIFF
--- a/TailorSoft_COCOLAND/UI_REVIEW.md
+++ b/TailorSoft_COCOLAND/UI_REVIEW.md
@@ -68,7 +68,7 @@ Mục tiêu:
 | Mã khách | `Select2` search hoặc nút “Thêm khách mới” (popup). |
 | Ngày đặt/ngày giao | Datepicker. |
 | Trạng thái | Dropdown với danh sách trạng thái cố định. |
-| Tổng tiền / Đã cọc | `type="number" step="1000"`; hiển thị gợi ý đơn vị VNĐ. |
+| Tổng tiền / Đã thanh toán | `type="number" step="1000"`; hiển thị gợi ý đơn vị VNĐ. |
 | Chọn sản phẩm + số đo | Sau bước này mở wizard/tab để nhập chi tiết sản phẩm & số đo. |
 
 ### Chi tiết đơn

--- a/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/createOrder.jsp
@@ -116,7 +116,7 @@
                 <div class="tab-pane fade" id="step4" role="tabpanel">
                     <div class="row">
                         <div class="col-md-6 mb-3">
-                            <label class="form-label">Đã cọc</label>
+                            <label class="form-label">Đã thanh toán</label>
                             <input type="number" name="deposit" class="form-control" step="1000" required>
                         </div>
                         <div class="col-md-3 mb-3">
@@ -138,7 +138,7 @@
                     <div class="text-center mb-3">
                         <img src="<c:url value='/img/payment-qr.jpg'/>" alt="QR Code" class="img-fluid" style="max-width:300px;">
                     </div>
-                    <div class="alert alert-secondary">Tổng: <span id="summaryTotal">0</span> ₫ - Đã cọc: <span id="summaryDeposit">0</span> ₫</div>
+                    <div class="alert alert-secondary">Tổng: <span id="summaryTotal">0</span> ₫ - Đã thanh toán: <span id="summaryDeposit">0</span> ₫</div>
                 </div>
             </div>
             <div class="d-flex justify-content-between mt-3">
@@ -299,7 +299,7 @@
     const depositInput = document.querySelector('input[name="deposit"]');
     function validatePayment(){
         if(Number(depositInput.value) > Number(totalInput.value)){
-            depositInput.setCustomValidity('Đã cọc không được vượt quá tổng tiền');
+            depositInput.setCustomValidity('Đã thanh toán không được vượt quá tổng tiền');
         }else{
             depositInput.setCustomValidity('');
         }

--- a/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/listOrder.jsp
@@ -55,9 +55,10 @@
                 <th>Ngày giao</th>
                 <th>Trạng thái</th>
                 <th class="text-end">Tổng tiền</th>
-                <th class="text-end">Đã cọc</th>
+                <th class="text-end">Đã thanh toán</th>
                 <th class="text-end">Còn lại</th>
                 <th class="text-center">Actions</th>
+                <th class="text-center">Thanh toán</th>
             </tr>
             </thead>
             <tbody>
@@ -92,6 +93,11 @@
                                    <i class="fa fa-times"></i>
                                </button>
                             </form>
+                        </c:if>
+                    </td>
+                    <td class="text-center">
+                        <c:if test="${o.deposit >= o.total}">
+                            <i class="fa fa-check text-success" title="Đã thanh toán"></i>
                         </c:if>
                     </td>
                 </tr>

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -19,7 +19,7 @@
                         </div>
                         <div class="col-md-6">
                             <p><strong>Tổng tiền:</strong> <fmt:formatNumber value="${order.total}" type="number" groupingUsed="true"/> ₫</p>
-                            <p><strong>Đã cọc:</strong> <fmt:formatNumber value="${order.deposit}" type="number" groupingUsed="true"/> ₫</p>
+                            <p><strong>Đã thanh toán:</strong> <fmt:formatNumber value="${order.deposit}" type="number" groupingUsed="true"/> ₫</p>
                             <p><strong>Còn lại:</strong> <fmt:formatNumber value="${order.total - order.deposit}" type="number" groupingUsed="true"/> ₫</p>
                             <button type="button" class="btn btn-outline-primary btn-sm" id="editOrderBtn" data-id="${order.id}" data-total="${order.total}" data-deposit="${order.deposit}"><i class="fa fa-pen"></i> Sửa tiền</button>
                         </div>
@@ -112,7 +112,7 @@
                     <input type="number" step="1000" class="form-control" name="total" id="orderTotal">
                 </div>
                 <div class="mb-3">
-                    <label class="form-label">Đã cọc</label>
+                    <label class="form-label">Đã thanh toán</label>
                     <input type="number" step="1000" class="form-control" name="deposit" id="orderDeposit">
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace all "Đã cọc" labels with "Đã thanh toán" in order creation, detail, list, and documentation
- show a check icon for orders that are fully paid in the order list

## Testing
- `ant -f TailorSoft_COCOLAND/build.xml compile`


------
https://chatgpt.com/codex/tasks/task_b_68905fb1a45c8322b5974c3319e299f1