### PR TITLE
Show measurement units in order detail view

### DIFF
--- a/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/measurement/MeasurementDAO.java
@@ -23,7 +23,7 @@ public class MeasurementDAO {
     public List<Measurement> findAll() {
         List<Measurement> list = new ArrayList<>();
         String sql = "SELECT tsd.ma_do, tsd.ma_khach, k.ho_ten, tsd.ma_loai, l.ten_loai, " +
-                "tsd.ma_thong_so, t.ten_thong_so, tsd.gia_tri, tsd.ghi_chu, tsd.ma_ct " +
+                "tsd.ma_thong_so, t.ten_thong_so, t.don_vi, tsd.gia_tri, tsd.ghi_chu, tsd.ma_ct " +
                 "FROM thong_so_do tsd " +
                 "JOIN khach_hang k ON tsd.ma_khach = k.ma_khach " +
                 "JOIN loai_san_pham l ON tsd.ma_loai = l.ma_loai " +
@@ -40,6 +40,7 @@ public class MeasurementDAO {
                 m.setProductTypeName(rs.getString("ten_loai"));
                 m.setMeasurementTypeId(rs.getInt("ma_thong_so"));
                 m.setMeasurementTypeName(rs.getString("ten_thong_so"));
+                m.setUnit(rs.getString("don_vi"));
                 m.setValue(rs.getDouble("gia_tri"));
                 m.setNote(rs.getString("ghi_chu"));
                 m.setOrderDetailId(rs.getInt("ma_ct"));
@@ -87,7 +88,8 @@ public class MeasurementDAO {
 
     public List<Map<String, Object>> findByOrderDetail(int detailId) {
         List<Map<String, Object>> list = new ArrayList<>();
-        String sql = "SELECT tsd.ma_do, lt.ten_thong_so, lt.don_vi, tsd.gia_tri " +
+        String sql = "SELECT tsd.ma_do, lt.ten_thong_so AS name, " +
+                "COALESCE(lt.don_vi, '') AS unit, tsd.gia_tri " +
                 "FROM thong_so_do tsd JOIN loai_thong_so lt ON tsd.ma_thong_so = lt.ma_thong_so " +
                 "WHERE tsd.ma_ct = ?";
         try (Connection c = DBConnect.getConnection();
@@ -97,8 +99,8 @@ public class MeasurementDAO {
                 while (rs.next()) {
                     Map<String, Object> m = new HashMap<>();
                     m.put("id", rs.getInt("ma_do"));
-                    m.put("name", rs.getString("ten_thong_so"));
-                    m.put("unit", rs.getString("don_vi"));
+                    m.put("name", rs.getString("name"));
+                    m.put("unit", rs.getString("unit"));
                     m.put("value", rs.getDouble("gia_tri"));
                     list.add(m);
                 }

--- a/TailorSoft_COCOLAND/src/java/model/Measurement.java
+++ b/TailorSoft_COCOLAND/src/java/model/Measurement.java
@@ -8,6 +8,7 @@ public class Measurement {
     private String productTypeName;
     private int measurementTypeId;
     private String measurementTypeName;
+    private String unit;
     private double value;
     private String note;
     private int orderDetailId;
@@ -16,7 +17,7 @@ public class Measurement {
 
     public Measurement(int id, int customerId, String customerName, int productTypeId,
                        String productTypeName, int measurementTypeId, String measurementTypeName,
-                       double value, String note, int orderDetailId) {
+                       String unit, double value, String note, int orderDetailId) {
         this.id = id;
         this.customerId = customerId;
         this.customerName = customerName;
@@ -24,6 +25,7 @@ public class Measurement {
         this.productTypeName = productTypeName;
         this.measurementTypeId = measurementTypeId;
         this.measurementTypeName = measurementTypeName;
+        this.unit = unit;
         this.value = value;
         this.note = note;
         this.orderDetailId = orderDetailId;
@@ -43,6 +45,8 @@ public class Measurement {
     public void setMeasurementTypeId(int measurementTypeId) { this.measurementTypeId = measurementTypeId; }
     public String getMeasurementTypeName() { return measurementTypeName; }
     public void setMeasurementTypeName(String measurementTypeName) { this.measurementTypeName = measurementTypeName; }
+    public String getUnit() { return unit; }
+    public void setUnit(String unit) { this.unit = unit; }
     public double getValue() { return value; }
     public void setValue(double value) { this.value = value; }
     public String getNote() { return note; }

--- a/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurement/listMeasurement.jsp
@@ -17,6 +17,7 @@
                 <th>Loại sản phẩm</th>
                 <th>Thông số</th>
                 <th>Giá trị</th>
+                <th>Đơn vị</th>
                 <th>Ghi chú</th>
             </tr>
             </thead>
@@ -28,6 +29,7 @@
                     <td>${m.productTypeName}</td>
                     <td>${m.measurementTypeName}</td>
                     <td>${m.value}</td>
+                    <td>${m.unit}</td>
                     <td>${m.note}</td>
                 </tr>
             </c:forEach>

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -138,11 +138,15 @@
                         $('#measurementList').append('<p class="text-muted">Không có thông số</p>');
                     } else {
                         list.forEach(function (m) {
-                            const label = m.name ? (m.unit ? `${m.name} (${m.unit})` : m.name) : '';
+                            const name = m.name || '';
+                            const unit = m.unit || '';
                             const value = m.value != null ? m.value : '';
                             const item = `<div class="mb-3">
-                                    <label class="form-label">${label}</label>
-                                    <input type="number" step="0.01" class="form-control" name="m_${m.id}" value="${value}" ${disabled ? 'disabled' : ''}>
+                                    <label class="form-label">${name}</label>
+                                    <div class="input-group">
+                                        <input type="number" step="0.01" class="form-control" name="m_${m.id}" value="${value}" ${disabled ? 'disabled' : ''}>
+                                        <span class="input-group-text">${unit}</span>
+                                    </div>
                                 </div>`;
                             $('#measurementList').append(item);
                         });


### PR DESCRIPTION
## Summary
- include explicit unit label when loading measurements for an order detail
- render measurement values with unit badges in order detail modal
- track unit strings in `Measurement` objects and show them in the measurement list

## Testing
- `ant -noinput -q`


------
https://chatgpt.com/codex/tasks/task_b_689062c08c008322ae6c8c437c82c93d