### PR TITLE
Remove measurement column and show detail info in modal

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
@@ -1,6 +1,7 @@
 package controller.order;
 
 import dao.order.OrderDAO;
+import dao.measurement.MeasurementDAO;
 import model.Order;
 import model.OrderDetail;
 
@@ -9,7 +10,9 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class OrderDetailController extends HttpServlet {
     private final OrderDAO orderDAO = new OrderDAO();
@@ -28,8 +31,16 @@ public class OrderDetailController extends HttpServlet {
             return;
         }
         List<OrderDetail> details = orderDAO.findDetailsByOrder(id);
+
+        MeasurementDAO mDao = new MeasurementDAO();
+        Map<Integer, List<Map<String, Object>>> msMap = new HashMap<>();
+        for (OrderDetail d : details) {
+            msMap.put(d.getId(), mDao.findByOrderDetail(d.getId()));
+        }
+
         request.setAttribute("order", order);
         request.setAttribute("details", details);
+        request.setAttribute("measurements", msMap);
         request.getRequestDispatcher("/jsp/order/orderDetail.jsp").forward(request, response);
     }
 }


### PR DESCRIPTION
## Summary
- remove measurement column from order detail table
- show fabric, price, quantity and notes in the product detail modal
- preload measurements on the server and render them in view/edit modals

## Testing
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_6891c9451cd48322bf2beeeeb2309e9d