### PR TITLE
fix: escape EL in dynamic measurement templates

### DIFF
--- a/TailorSoft_COCOLAND/web/jsp/measurement/createMeasurement.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/measurement/createMeasurement.jsp
@@ -39,9 +39,9 @@ document.getElementById('productType').addEventListener('change', function(){
                 const div = document.createElement('div');
                 div.className = 'mb-3';
                 div.innerHTML =
-                    `<label class="form-label">${mt.name} (${mt.unit})</label>`+
-                    `<input type="number" step="0.1" name="value_${mt.id}" class="form-control"/>`+
-                    `<input type="text" name="note_${mt.id}" class="form-control mt-1" placeholder="Ghi chú"/>`;
+                    '<label class="form-label">' + mt.name + ' (' + mt.unit + ')</label>'+
+                    '<input type="number" step="0.1" name="value_' + mt.id + '" class="form-control"/>'+
+                    '<input type="text" name="note_' + mt.id + '" class="form-control mt-1" placeholder="Ghi chú"/>';
                 container.appendChild(div);
             });
         });

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -309,10 +309,9 @@
           list.forEach(m => {
             const col = document.createElement('div');
             col.className = 'col-md-6';
-            col.innerHTML = `
-              <label class="form-label">${m.name} (${m.unit})</label>
-              <input type="text" class="form-control" value="${formatValue(m.value)}" disabled>
-            `;
+            col.innerHTML =
+              '<label class="form-label">' + m.name + ' (' + m.unit + ')</label>' +
+              '<input type="text" class="form-control" value="' + formatValue(m.value) + '" disabled>';
             $viewFields.appendChild(col);
           });
         }
@@ -339,10 +338,10 @@
           list.forEach(m => {
             const col = document.createElement('div');
             col.className = 'col-md-6';
-            col.innerHTML = `
-              <label class="form-label">${m.name} (${m.unit})</label>
-              <input type="number" class="form-control" step="0.1" name="m_${m.id}" value="${formatValue(m.value)}" required>
-            `;
+            col.innerHTML =
+              '<label class="form-label">' + m.name + ' (' + m.unit + ')</label>' +
+              '<input type="number" class="form-control" step="0.1" name="m_' + m.id +
+              '" value="' + formatValue(m.value) + '" required>';
             $fields.appendChild(col);
           });
         }
@@ -409,7 +408,7 @@
             const resp = await fetch(toggleStatusUrl, {
               method: 'POST',
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-              body: `id=${orderId}`
+              body: 'id=' + orderId
             });
             if (!resp.ok) throw new Error('HTTP ' + resp.status);
             const data = await resp.json();


### PR DESCRIPTION
## Summary
- prevent JSP EL from evaluating dynamic measurement templates
- avoid server-side parsing of toggle status payload

## Testing
- `ant test`

------
https://chatgpt.com/codex/tasks/task_b_6891d4454574832292755c8431306234