### PR TITLE
Handle missing material in order detail

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
@@ -87,6 +87,9 @@ public class OrderCreateController extends HttpServlet {
                             String note = request.getParameter("note" + idx);
 
                             Material material = materialId > 0 ? mDao.findById(materialId) : null;
+                            if (material == null) {
+                                materialId = 0;
+                            }
 
                             OrderDetail d = new OrderDetail();
                             d.setOrderId(orderId);

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -120,7 +120,11 @@ public class OrderDAO {
             try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setInt(3, detail.getMaterialId());
+                if (detail.getMaterialId() > 0) {
+                    ps.setInt(3, detail.getMaterialId());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
                 ps.setString(4, detail.getMaterialName());
                 ps.setDouble(5, detail.getUnitPrice());
                 ps.setInt(6, detail.getQuantity());
@@ -138,7 +142,11 @@ public class OrderDAO {
                  PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setInt(3, detail.getMaterialId());
+                if (detail.getMaterialId() > 0) {
+                    ps.setInt(3, detail.getMaterialId());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
                 ps.setString(4, detail.getMaterialName());
                 ps.setDouble(5, detail.getUnitPrice());
                 ps.setInt(6, detail.getQuantity());


### PR DESCRIPTION
## Summary
- Handle invalid material references when creating orders
- Write null material IDs to order details to avoid foreign key violations

## Testing
- `ant test`

------
https://chatgpt.com/codex/tasks/task_b_68930c25ffbc83228b0ad2d77f43b307