### PR TITLE
Send completion email after order confirmation

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderToggleStatusController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderToggleStatusController.java
@@ -42,7 +42,7 @@ public class OrderToggleStatusController extends HttpServlet {
         if ("Hoan thanh".equals(next)) {
             try {
                 List<OrderDetail> details = dao.findDetailsByOrder(id);
-                notificationService.sendOrderEmail(o.getCustomerEmail(), o, details);
+                notificationService.sendOrderCompletionEmail(o.getCustomerEmail(), o, details);
                 notificationService.sendOrderZns(o.getCustomerPhone(), o, details);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Send notification failed", e);

--- a/TailorSoft_COCOLAND/src/java/service/NotificationService.java
+++ b/TailorSoft_COCOLAND/src/java/service/NotificationService.java
@@ -48,6 +48,25 @@ public class NotificationService {
         LOGGER.info("Sent order email to " + toEmail);
     }
 
+    public void sendOrderCompletionEmail(String toEmail, Order order, List<OrderDetail> details) throws MessagingException, UnsupportedEncodingException {
+        if (toEmail == null || toEmail.isBlank()) {
+            LOGGER.warning("Recipient email is empty; skip sending email");
+            return;
+        }
+        String subject = "Đơn hàng #" + order.getId() + " đã hoàn thành";
+        StringBuilder body = new StringBuilder();
+        body.append("Chào quý khách,\n\n")
+            .append("Đơn hàng của bạn đã hoàn thành.\n")
+            .append("Sản phẩm đã đặt: ").append(formatItems(details)).append("\n")
+            .append("Tổng tiền: ").append(order.getTotal()).append("\n")
+            .append("Tiền đã thanh toán: ").append(order.getDeposit()).append("\n")
+            .append("Ngày đặt: ").append(DF.format(order.getOrderDate())).append("\n")
+            .append("Ngày hẹn: ").append(DF.format(order.getDeliveryDate())).append("\n\n")
+            .append("Cảm ơn bạn!");
+        SendMail.sendMail(toEmail, subject, body.toString());
+        LOGGER.info("Sent order completion email to " + toEmail);
+    }
+
     public void sendOrderZns(String phone, Order order, List<OrderDetail> details) {
         if (ZALO_ACCESS_TOKEN == null || ZALO_TEMPLATE_ID == null) {
             LOGGER.warning("Zalo credentials not set; skip sending ZNS");


### PR DESCRIPTION
## Summary
- add NotificationService.sendOrderCompletionEmail to email customers when an order is finished
- trigger sendOrderCompletionEmail in OrderToggleStatusController when status becomes "Hoan thanh"

## Testing
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_68930f877e848322a3ff3701a11d643b