### PR TITLE
Load email config from env or classpath

### DIFF
--- a/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
+++ b/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
@@ -1,6 +1,5 @@
 package units;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -10,20 +9,30 @@ public class EmailConfig {
     private static final Properties props = new Properties();
 
     static {
-        try {
-            // Đường dẫn tới file trong thư mục conf (cùng cấp với thư mục java)
-            FileInputStream input = new FileInputStream("src/conf/email.properties");
-            props.load(input);
+        try (InputStream input = EmailConfig.class.getClassLoader().getResourceAsStream("email.properties")) {
+            if (input != null) {
+                props.load(input);
+            } else {
+                System.err.println("⚠️ Không tìm thấy file email.properties trong classpath.");
+            }
         } catch (IOException e) {
-            System.err.println("❌ Không đọc được file email.properties: " + e.getMessage());
+            System.err.println("❌ Lỗi khi đọc email.properties: " + e.getMessage());
         }
     }
 
     public static String getEmail() {
+        String envEmail = System.getenv("GMAIL_USER");
+        if (envEmail != null && !envEmail.isBlank()) {
+            return envEmail;
+        }
         return props.getProperty("email");
     }
 
     public static String getPassword() {
+        String envPass = System.getenv("GMAIL_PASS");
+        if (envPass != null && !envPass.isBlank()) {
+            return envPass;
+        }
         return props.getProperty("password");
     }
 


### PR DESCRIPTION
## Summary
- load email.properties from classpath instead of hard-coded path
- allow overriding email credentials via GMAIL_USER and GMAIL_PASS env vars

## Testing
- `javac -cp src/java:lib/* src/java/units/*.java`


------
https://chatgpt.com/codex/tasks/task_b_689312404d6c8322b1b95920e1048568