### PR TITLE
Use email.properties for SMTP credentials

### DIFF
--- a/TailorSoft_COCOLAND/README.md
+++ b/TailorSoft_COCOLAND/README.md
@@ -1,2 +1,13 @@
 
 Thư mục này chứa mã nguồn của ứng dụng web TailorSoft COCOLAND. Các chức năng được tách thành các gói phục vụ quản lý khách hàng, kho vải, đơn hàng và số đo với các lớp DAO cùng trang JSP đơn giản. Tất cả giao diện JSP đều hiển thị tiếng Việt.
+
+## Cấu hình gửi email
+
+Ứng dụng sử dụng duy nhất tệp `email.properties` để lấy thông tin đăng nhập khi gửi mail. Tạo tệp `src/conf/email.properties` với nội dung:
+
+```
+email=youraddress@gmail.com
+password=your-app-password
+```
+
+Tệp này cần nằm trong classpath khi build để tính năng gửi mail hoạt động.

--- a/TailorSoft_COCOLAND/src/conf/email.properties
+++ b/TailorSoft_COCOLAND/src/conf/email.properties
@@ -1,3 +1,3 @@
-# Gmail credentials used when environment variables are not provided
+# Gmail SMTP credentials
 email=longpdhe171902@fpt.edu.vn
 password=nshj rjfa inmr izri

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateController.java
@@ -132,11 +132,10 @@ public class OrderCreateController extends HttpServlet {
                 Customer customer = customerDAO.findById(customerId);
                 List<OrderDetail> details = orderDAO.findDetailsByOrder(orderId);
                 NotificationService notify = new NotificationService();
-                try {
-                    notify.sendOrderEmail(customer, order, details);
-                    notify.sendOrderZns(customer.getPhone(), order, details);
-                } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Send notification failed", e);
+                boolean emailSent = notify.sendOrderEmail(customer, order, details);
+                notify.sendOrderZns(customer.getPhone(), order, details);
+                if (!emailSent) {
+                    LOGGER.warning("Order email not sent");
                 }
 
                 response.sendRedirect(request.getContextPath() + "/orders?msg=created");

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderSendEmailController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderSendEmailController.java
@@ -36,12 +36,12 @@ public class OrderSendEmailController extends HttpServlet {
         try {
             Customer customer = customerDAO.findById(order.getCustomerId());
             List<OrderDetail> details = orderDAO.findDetailsByOrder(orderId);
-            notificationService.sendOrderEmail(customer, order, details);
+            boolean emailSent = notificationService.sendOrderEmail(customer, order, details);
             notificationService.sendOrderZns(order.getCustomerPhone(), order, details);
+            resp.setStatus(emailSent ? HttpServletResponse.SC_OK : HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Send notification failed", e);
-            throw new ServletException(e);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
-        resp.setStatus(HttpServletResponse.SC_OK);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/service/NotificationService.java
+++ b/TailorSoft_COCOLAND/src/java/service/NotificationService.java
@@ -31,10 +31,10 @@ public class NotificationService {
     private static final String ZALO_TEMPLATE_ID = System.getenv("ZALO_TEMPLATE_ID");
     private static final SimpleDateFormat DF = new SimpleDateFormat("dd/MM/yyyy");
 
-    public void sendOrderEmail(Customer customer, Order order, List<OrderDetail> details) throws MessagingException, UnsupportedEncodingException {
+    public boolean sendOrderEmail(Customer customer, Order order, List<OrderDetail> details) {
         if (customer == null || customer.getEmail() == null || customer.getEmail().isBlank()) {
             LOGGER.warning("Recipient email is empty; skip sending email");
-            return;
+            return false;
         }
         String toEmail = customer.getEmail();
         String subject = "[COCOLAND] Xác nhận đơn hàng #" + order.getId() + " – Cảm ơn " + customer.getName();
@@ -63,8 +63,14 @@ public class NotificationService {
             .append("Trân trọng,\n")
             .append("Nguyễn Hoàng Thái Thịnh\n")
             .append("Bộ phận Chăm sóc Khách hàng – COCOLAND");
-        SendMail.sendMail(toEmail, subject, body.toString());
-        LOGGER.info("Sent order email to " + toEmail);
+        try {
+            SendMail.sendMail(toEmail, subject, body.toString());
+            LOGGER.info("Sent order email to " + toEmail);
+            return true;
+        } catch (IllegalStateException | MessagingException | UnsupportedEncodingException ex) {
+            LOGGER.log(Level.WARNING, "Send order email failed", ex);
+            return false;
+        }
     }
 
     public void sendOrderZns(String phone, Order order, List<OrderDetail> details) {

--- a/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
+++ b/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
@@ -21,19 +21,19 @@ public class EmailConfig {
     }
 
     public static String getEmail() {
-        String envEmail = System.getenv("GMAIL_USER");
-        if (envEmail != null && !envEmail.isBlank()) {
-            return envEmail;
+        String email = props.getProperty("email");
+        if (email == null || email.isBlank()) {
+            throw new IllegalStateException("Missing 'email' in email.properties");
         }
-        return props.getProperty("email");
+        return email;
     }
 
     public static String getPassword() {
-        String envPass = System.getenv("GMAIL_PASS");
-        if (envPass != null && !envPass.isBlank()) {
-            return envPass;
+        String password = props.getProperty("password");
+        if (password == null || password.isBlank()) {
+            throw new IllegalStateException("Missing 'password' in email.properties");
         }
-        return props.getProperty("password");
+        return password;
     }
 
 }


### PR DESCRIPTION
## Summary
- Remove environment variable fallbacks in `EmailConfig` and validate required properties
- Update email configuration README instructions
- Clarify `email.properties` comment
- Propagate email send status in order notifications to avoid crashes when credentials are missing

## Testing
- `ant test`


------
https://chatgpt.com/codex/tasks/task_b_68937731979c832298000e6848b90866