### PR TITLE
Improve email configuration loading

### DIFF
--- a/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
+++ b/TailorSoft_COCOLAND/src/java/units/EmailConfig.java
@@ -12,14 +12,36 @@ public class EmailConfig {
     private static final Properties props = new Properties();
 
     static {
-        try (InputStream in = EmailConfig.class.getClassLoader().getResourceAsStream("conf/email.properties")) {
+        // Try loading configuration from the bundled resources first
+        loadFromClasspath("conf/email.properties");
+        // Some IDEs place resources directly in the classpath root
+        if (props.isEmpty()) {
+            loadFromClasspath("email.properties");
+        }
+
+        // Fallback to environment variables so the application can run
+        // even when the properties file is missing.  This is useful in
+        // containerised deployments where secrets are provided via env vars.
+        if (props.isEmpty()) {
+            String envMail = System.getenv("EMAIL_USER");
+            String envPwd  = System.getenv("EMAIL_PASSWORD");
+            if (envMail != null) props.setProperty("email", envMail);
+            if (envPwd  != null) props.setProperty("password", envPwd);
+            if (props.isEmpty()) {
+                System.err.println("email.properties not found and no environment variables provided");
+            }
+        }
+    }
+
+    private static void loadFromClasspath(String path) {
+        try (InputStream in = EmailConfig.class.getClassLoader().getResourceAsStream(path)) {
             if (in != null) {
                 props.load(in);
             } else {
-                System.err.println("email.properties not found");
+                System.err.println(path + " not found");
             }
         } catch (IOException e) {
-            System.err.println(" Failed to load email.properties: " + e.getMessage());
+            System.err.println("Failed to load " + path + ": " + e.getMessage());
         }
     }
 
@@ -32,7 +54,9 @@ public class EmailConfig {
     }
 
     public static String getPassword() {
-        return props.getProperty("password", "");
+        // Gmail application passwords are often written with spaces for
+        // readability.  Remove them to avoid authentication errors.
+        return props.getProperty("password", "").replace(" ", "");
     }
     
     


### PR DESCRIPTION
## Summary
- make `EmailConfig` search multiple locations for `email.properties`
- fall back to environment variables if the configuration file is missing
- strip spaces from the password to avoid Gmail authentication errors

## Testing
- `javac -cp lib/jakarta.mail-2.0.1.jar:lib/jakarta.activation-api-2.1.2.jar -d /tmp/classes src/java/units/EmailConfig.java src/java/units/SendMail.java`

------
https://chatgpt.com/codex/tasks/task_b_689481b68d8c8322b93caf9920a7823f