### PR TITLE
Add input limits and paginate product and material lists

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/material/MaterialListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/material/MaterialListController.java
@@ -24,12 +24,13 @@ public class MaterialListController extends HttpServlet {
             } catch (NumberFormatException ignored) {
             }
         }
-        List<Material> all = materialDAO.findAll();
-        int total = all.size();
-        int from = Math.max(0, (page - 1) * PAGE_SIZE);
-        int to = Math.min(from + PAGE_SIZE, total);
-        List<Material> materials = all.subList(from, to);
+        int total = materialDAO.count();
         int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
+        if (page > totalPages) {
+            page = totalPages == 0 ? 1 : totalPages;
+        }
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        List<Material> materials = materialDAO.findRange(from, PAGE_SIZE);
         request.setAttribute("materials", materials);
         request.setAttribute("currentPage", page);
         request.setAttribute("totalPages", totalPages);

--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateControllerTest.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderCreateControllerTest.java
@@ -1,0 +1,115 @@
+package controller.order;
+
+import dao.material.MaterialDAO;
+import dao.measurement.MeasurementDAO;
+import dao.order.OrderDAO;
+import dao.producttype.ProductTypeDAO;
+import jakarta.servlet.http.HttpServletRequest;
+import model.Measurement;
+import model.Material;
+import model.Order;
+import model.OrderDetail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.util.*;
+
+public class OrderCreateControllerTest {
+    public static void main(String[] args) throws Exception {
+        testTooManyProducts();
+        testTooManyMaterialTypes();
+        System.out.println("Tests completed");
+    }
+
+    static void testTooManyProducts() throws Exception {
+        OrderCreateController ctrl = new OrderCreateController();
+        Field f = OrderCreateController.class.getDeclaredField("productTypeDAO");
+        f.setAccessible(true);
+        f.set(ctrl, new StubProductTypeDAO());
+        Order order = new Order();
+        order.setId(1);
+        order.setCustomerId(1);
+
+        Map<String, String[]> params = new HashMap<>();
+        for (int i = 1; i <= OrderCreateController.MAX_ITEMS + 1; i++) {
+            params.put("productTypeId" + i, new String[]{"1"});
+            params.put("quantity" + i, new String[]{"1"});
+        }
+        HttpServletRequest req = mockRequest(params);
+        try {
+            ctrl.buildOrderDetails(req, new StubOrderDAO(), new StubMeasurementDAO(), new StubMaterialDAO(), order);
+            System.out.println("testTooManyProducts FAILED");
+        } catch (IllegalArgumentException ex) {
+            System.out.println("testTooManyProducts PASSED");
+        }
+    }
+
+    static void testTooManyMaterialTypes() throws Exception {
+        OrderCreateController ctrl = new OrderCreateController();
+        Field f = OrderCreateController.class.getDeclaredField("productTypeDAO");
+        f.setAccessible(true);
+        f.set(ctrl, new StubProductTypeDAO());
+        Order order = new Order();
+        order.setId(1);
+        order.setCustomerId(1);
+
+        Map<String, String[]> params = new HashMap<>();
+        int limit = OrderCreateController.MAX_MATERIAL_TYPES + 1;
+        for (int i = 1; i <= limit; i++) {
+            params.put("productTypeId" + i, new String[]{"1"});
+            params.put("quantity" + i, new String[]{"1"});
+            params.put("materialId_" + i, new String[]{String.valueOf(i)});
+        }
+        HttpServletRequest req = mockRequest(params);
+        try {
+            ctrl.buildOrderDetails(req, new StubOrderDAO(), new StubMeasurementDAO(), new StubMaterialDAO(), order);
+            System.out.println("testTooManyMaterialTypes FAILED");
+        } catch (IllegalArgumentException ex) {
+            System.out.println("testTooManyMaterialTypes PASSED");
+        }
+    }
+
+    static HttpServletRequest mockRequest(Map<String, String[]> params) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class[]{HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getParameterMap")) {
+                        return params;
+                    }
+                    if (method.getName().equals("getParameter")) {
+                        String[] v = params.get((String) args[0]);
+                        return v != null && v.length > 0 ? v[0] : null;
+                    }
+                    return null;
+                });
+    }
+
+    static class StubOrderDAO extends OrderDAO {
+        public StubOrderDAO() { super(null); }
+        @Override
+        public int insertDetail(OrderDetail detail) throws SQLException { return 0; }
+    }
+
+    static class StubMeasurementDAO extends MeasurementDAO {
+        public StubMeasurementDAO() { super(null); }
+        @Override
+        public void insert(Measurement m) {}
+    }
+
+    static class StubMaterialDAO extends MaterialDAO {
+        public StubMaterialDAO() { super(null); }
+        @Override
+        public Material findById(int id) { return null; }
+        @Override
+        public void decreaseQuantity(int id, double amount) {}
+    }
+
+    static class StubProductTypeDAO extends ProductTypeDAO {
+        @Override
+        public String cacheFindName(int id) {
+            return "PT";
+        }
+    }
+}

--- a/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeListController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/producttype/ProductTypeListController.java
@@ -27,12 +27,13 @@ public class ProductTypeListController extends HttpServlet {
             } catch (NumberFormatException ignored) {
             }
         }
-        List<ProductType> all = productTypeDAO.findAll();
-        int total = all.size();
-        int from = Math.max(0, (page - 1) * PAGE_SIZE);
-        int to = Math.min(from + PAGE_SIZE, total);
-        List<ProductType> list = all.subList(from, to);
+        int total = productTypeDAO.count();
         int totalPages = (int) Math.ceil(total / (double) PAGE_SIZE);
+        if (page > totalPages) {
+            page = totalPages == 0 ? 1 : totalPages;
+        }
+        int from = Math.max(0, (page - 1) * PAGE_SIZE);
+        List<ProductType> list = productTypeDAO.findRange(from, PAGE_SIZE);
         Map<Integer, List<MeasurementType>> map = new HashMap<>();
         for (ProductType pt : list) {
             map.put(pt.getId(), productTypeDAO.findMeasurementTypes(pt.getId()));

--- a/TailorSoft_COCOLAND/src/java/dao/material/MaterialDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/material/MaterialDAO.java
@@ -41,6 +41,46 @@ public class MaterialDAO {
         return list;
     }
 
+    public int count() {
+        String sql = "SELECT COUNT(*) FROM kho_vai";
+        try (Connection c = DBConnect.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public List<Material> findRange(int offset, int limit) {
+        List<Material> list = new ArrayList<>();
+        String sql = "SELECT ma_vai, ten_vai, mau_sac, xuat_xu, gia_thanh, so_luong, hinh_hoa_don FROM kho_vai ORDER BY ma_vai LIMIT ? OFFSET ?";
+        try (Connection c = DBConnect.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Material m = new Material();
+                    m.setId(rs.getInt("ma_vai"));
+                    m.setName(rs.getString("ten_vai"));
+                    m.setColor(rs.getString("mau_sac"));
+                    m.setOrigin(rs.getString("xuat_xu"));
+                    m.setPrice(rs.getDouble("gia_thanh"));
+                    m.setQuantity(rs.getDouble("so_luong"));
+                    m.setInvoiceImage(rs.getString("hinh_hoa_don"));
+                    list.add(m);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
     public void insert(Material material) {
         String sql = "INSERT INTO kho_vai(ten_vai, mau_sac, xuat_xu, gia_thanh, so_luong, hinh_hoa_don) VALUES(?,?,?,?,?,?)";
         try (Connection c = DBConnect.getConnection();

--- a/TailorSoft_COCOLAND/src/java/dao/producttype/ProductTypeDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/producttype/ProductTypeDAO.java
@@ -31,6 +31,42 @@ public class ProductTypeDAO {
         return list;
     }
 
+    public int count() {
+        String sql = "SELECT COUNT(*) FROM loai_san_pham";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public List<ProductType> findRange(int offset, int limit) {
+        List<ProductType> list = new ArrayList<>();
+        String sql = "SELECT ma_loai, ten_loai, ky_hieu FROM loai_san_pham ORDER BY ma_loai LIMIT ? OFFSET ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            ps.setInt(2, offset);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ProductType pt = new ProductType();
+                    pt.setId(rs.getInt("ma_loai"));
+                    pt.setName(rs.getString("ten_loai"));
+                    pt.setCode(rs.getString("ky_hieu"));
+                    list.add(pt);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
     public ProductType findById(int id) {
         String sql = "SELECT ma_loai, ten_loai, ky_hieu FROM loai_san_pham WHERE ma_loai = ?";
         try (Connection conn = DBConnect.getConnection();


### PR DESCRIPTION
## Summary
- Prevent slowdown by paginating product type and material listings via SQL count and range queries
- Limit order creation to a maximum number of items and fabric types with clear validation errors
- Add unit tests verifying limits for excessive products and fabric types

## Testing
- `javac -d build/classes -cp 'lib/*' $(find src/java -name '*.java')`
- `java -cp build/classes:lib/* controller.order.OrderCreateControllerTest`


------
https://chatgpt.com/codex/tasks/task_b_689605bbd0908322b0ae4c2cc559eb48