### PR TITLE
Fix measurement value display in order details

### DIFF
--- a/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
+++ b/TailorSoft_COCOLAND/src/java/controller/order/OrderDetailController.java
@@ -1,5 +1,6 @@
 package controller.order;
 
+import com.google.gson.Gson;
 import dao.order.OrderDAO;
 import dao.measurement.MeasurementDAO;
 import model.Order;
@@ -38,9 +39,11 @@ public class OrderDetailController extends HttpServlet {
             msMap.put(d.getId(), mDao.findByOrderDetail(d.getId()));
         }
 
+        String msJson = new Gson().toJson(msMap);
+
         request.setAttribute("order", order);
         request.setAttribute("details", details);
-        request.setAttribute("measurements", msMap);
+        request.setAttribute("measurementsJson", msJson);
         request.getRequestDispatcher("/jsp/order/orderDetail.jsp").forward(request, response);
     }
 }

--- a/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
+++ b/TailorSoft_COCOLAND/src/java/dao/order/OrderDAO.java
@@ -120,7 +120,11 @@ public class OrderDAO {
             try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setInt(3, detail.getMaterialId());
+                if (detail.getMaterialId() > 0) {
+                    ps.setInt(3, detail.getMaterialId());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
                 ps.setString(4, detail.getMaterialName());
                 ps.setDouble(5, detail.getUnitPrice());
                 ps.setInt(6, detail.getQuantity());
@@ -138,7 +142,11 @@ public class OrderDAO {
                  PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, detail.getOrderId());
                 ps.setString(2, detail.getProductType());
-                ps.setInt(3, detail.getMaterialId());
+                if (detail.getMaterialId() > 0) {
+                    ps.setInt(3, detail.getMaterialId());
+                } else {
+                    ps.setNull(3, Types.INTEGER);
+                }
                 ps.setString(4, detail.getMaterialName());
                 ps.setDouble(5, detail.getUnitPrice());
                 ps.setInt(6, detail.getQuantity());

--- a/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
+++ b/TailorSoft_COCOLAND/web/jsp/order/orderDetail.jsp
@@ -1,11 +1,6 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ page import="com.google.gson.Gson" %>
-<%
-  Object msObj = request.getAttribute("measurements");
-  String measurementsJson = msObj != null ? new Gson().toJson(msObj) : "{}";
-%>
 <c:set var="pageTitle" value="Chi tiết đơn hàng"/>
 <jsp:include page="/jsp/common/header.jsp"/>
 <jsp:include page="/jsp/common/sidebar.jsp"/>
@@ -263,7 +258,7 @@
 </div>
 
 <script>
-    const measurements = <%= measurementsJson %>;
+    const measurements = ${measurementsJson};
 
     function showPayment(src) {
         document.getElementById('paymentModalImage').src = src;


### PR DESCRIPTION
## Summary
- Serialize measurement info in `OrderDetailController` and pass as JSON for the JSP to render
- Allow `OrderDAO` to store null material IDs when fabric is not selected
- Clean up JSP to consume provided JSON and remove server-side Gson usage

## Testing
- `javac -cp "lib/*:src/java" src/java/controller/order/OrderDetailController.java src/java/dao/order/OrderDAO.java`
- `ant test` *(fails: command not found; attempted to install ant but `ca-certificates-java` post-install step failed)*

------
https://chatgpt.com/codex/tasks/task_b_68960d05fcfc8322b055a2fa1c680858